### PR TITLE
fix(backward): reimport functions from sprig to maintain backward compatibility

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -3,8 +3,8 @@ module sprout_benchmarks
 go 1.21.0
 
 require (
-	github.com/go-sprout/sprout v0.0.0-20240331203623-2cbfca5974e1
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/go-sprout/sprout v0.3.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/sprig_backward_compatibility.go
+++ b/sprig_backward_compatibility.go
@@ -1,0 +1,66 @@
+package sprout
+
+import (
+	htemplate "html/template"
+	ttemplate "text/template"
+)
+
+// HermeticTxtFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
+func HermeticTxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
+	r := TxtFuncMap(opts...)
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// HermeticHtmlFuncMap returns an 'html/template'.Funcmap with only repeatable functions.
+func HermeticHtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
+	r := HtmlFuncMap(opts...)
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// TxtFuncMap returns a 'text/template'.FuncMap
+func TxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
+	return ttemplate.FuncMap(FuncMap(opts...))
+}
+
+// HtmlFuncMap returns an 'html/template'.Funcmap
+func HtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
+	return htemplate.FuncMap(FuncMap(opts...))
+}
+
+// GenericFuncMap returns a copy of the basic function map as a map[string]interface{}.
+func GenericFuncMap(opts ...FunctionHandlerOption) map[string]interface{} {
+	return FuncMap(opts...)
+}
+
+// These functions are not guaranteed to evaluate to the same result for given input, because they
+// refer to the environment or global state.
+var nonhermeticFunctions = []string{
+	// Date functions
+	"date",
+	"dateInZone",
+	"dateModify",
+	"now",
+	"htmlDate",
+	"htmlDateInZone",
+
+	// Strings
+	"randAlphaNum",
+	"randAlpha",
+	"randAscii",
+	"randNumeric",
+	"randBytes",
+	"uuidv4",
+
+	// OS
+	"env",
+	"expandenv",
+
+	// Network
+	"getHostByName",
+}

--- a/sprig_backward_compatibility_test.go
+++ b/sprig_backward_compatibility_test.go
@@ -1,0 +1,31 @@
+package sprout
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sprigFunctionCount = 203
+
+func TestSprig_backward_compatibility(t *testing.T) {
+	gfm := GenericFuncMap()
+	assert.NotNil(t, gfm)
+	assert.GreaterOrEqual(t, len(gfm), sprigFunctionCount)
+
+	hfm := HtmlFuncMap()
+	assert.NotNil(t, hfm)
+	assert.GreaterOrEqual(t, len(hfm), sprigFunctionCount)
+
+	tfm := TxtFuncMap()
+	assert.NotNil(t, tfm)
+	assert.GreaterOrEqual(t, len(tfm), sprigFunctionCount)
+
+	hhfm := HermeticHtmlFuncMap()
+	assert.NotNil(t, hhfm)
+	assert.Equal(t, len(hhfm), len(gfm)-len(nonhermeticFunctions))
+
+	htfm := HermeticTxtFuncMap()
+	assert.NotNil(t, htfm)
+	assert.Equal(t, len(htfm), len(gfm)-len(nonhermeticFunctions))
+}


### PR DESCRIPTION
## Description
This pull request reimports several functions from the Sprig library to maintain backward compatibility. This is marked as a regression issue

## Changes
- Reimported `HermeticTxtFuncMap`, `HermeticHtmlFuncMap`, `TxtFuncMap`, `HtmlFuncMap`, `GenericFuncMap` from Sprig.

## Fixes #29

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.