### PR TITLE
feat: add functions and docs to conversions group

### DIFF
--- a/conversion_functions.go
+++ b/conversion_functions.go
@@ -8,6 +8,23 @@ import (
 	"github.com/spf13/cast"
 )
 
+// ToBool converts a value to a boolean.
+//
+// Parameters:
+//
+//	v any - the value to convert to a boolean. This can be any types reasonably be converted to true or false.
+//
+// Returns:
+//
+//	bool - the boolean representation of the value.
+//
+// Example:
+//
+//	{{ "true" | toBool }} // Output: true
+func (fh *FunctionHandler) ToBool(v any) bool {
+	return cast.ToBool(v)
+}
+
 // ToInt converts a value to an int using robust type casting.
 //
 // Parameters:
@@ -40,6 +57,40 @@ func (fh *FunctionHandler) ToInt(v any) int {
 //	{{ "123456789012" | toInt64 }} // Output: 123456789012
 func (fh *FunctionHandler) ToInt64(v any) int64 {
 	return cast.ToInt64(v)
+}
+
+// ToUint converts a value to a uint.
+//
+// Parameters:
+//
+//	v any - the value to convert to uint. This value can be of any type that is numerically convertible.
+//
+// Returns:
+//
+//	uint - the uint representation of the value.
+//
+// Example:
+//
+//	{{ "123" | toUint }} // Output: 123
+func (fh *FunctionHandler) ToUint(v any) uint {
+	return cast.ToUint(v)
+}
+
+// ToUint64 converts a value to a uint64.
+//
+// Parameters:
+//
+//	v any - the value to convert to uint64. This value can be of any type that is numerically convertible.
+//
+// Returns:
+//
+//	uint64 - the uint64 representation of the value.
+//
+// Example:
+//
+//	{{ "123456789012345" | toUint64 }} // Output: 123456789012345
+func (fh *FunctionHandler) ToUint64(v any) uint64 {
+	return cast.ToUint64(v)
 }
 
 // ToFloat64 converts a value to a float64.

--- a/conversion_functions_test.go
+++ b/conversion_functions_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func TestToBool(t *testing.T) {
+	var tests = testCases{
+		{"TestBool", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-true", map[string]any{"V": true}},
+		{"TestInt", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-true", map[string]any{"V": 1}},
+		{"TestInt32", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-true", map[string]any{"V": int32(1)}},
+		{"TestFloat64", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-true", map[string]any{"V": float64(1.42)}},
+		{"TestString", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-true", map[string]any{"V": "true"}},
+		{"TestStringFalse", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-false", map[string]any{"V": "false"}},
+		{"TestStringInvalid", `{{$v := toBool .V }}{{kindOf $v}}-{{$v}}`, "bool-false", map[string]any{"V": "invalid"}},
+	}
+
+	runTestCases(t, tests)
+}
+
 func TestToInt(t *testing.T) {
 	var tests = testCases{
 		{"TestInt", `{{$v := toInt .V }}{{kindOf $v}}-{{$v}}`, "int-1", map[string]any{"V": 1}},
@@ -24,6 +38,30 @@ func TestToInt64(t *testing.T) {
 		{"TestFloat64", `{{$v := toInt64 .V }}{{typeOf $v}}-{{$v}}`, "int64-1", map[string]any{"V": float64(1.42)}},
 		{"TestBool", `{{$v := toInt64 .V }}{{typeOf $v}}-{{$v}}`, "int64-1", map[string]any{"V": true}},
 		{"TestString", `{{$v := toInt64 .V }}{{typeOf $v}}-{{$v}}`, "int64-1", map[string]any{"V": "1"}},
+	}
+
+	runTestCases(t, tests)
+}
+
+func TestToUint(t *testing.T) {
+	var tests = testCases{
+		{"TestInt", `{{$v := toUint .V }}{{kindOf $v}}-{{$v}}`, "uint-1", map[string]any{"V": 1}},
+		{"TestInt32", `{{$v := toUint .V }}{{kindOf $v}}-{{$v}}`, "uint-1", map[string]any{"V": int32(1)}},
+		{"TestFloat64", `{{$v := toUint .V }}{{kindOf $v}}-{{$v}}`, "uint-1", map[string]any{"V": float64(1.42)}},
+		{"TestBool", `{{$v := toUint .V }}{{kindOf $v}}-{{$v}}`, "uint-1", map[string]any{"V": true}},
+		{"TestString", `{{$v := toUint .V }}{{kindOf $v}}-{{$v}}`, "uint-1", map[string]any{"V": "1"}},
+	}
+
+	runTestCases(t, tests)
+}
+
+func TestToUint64(t *testing.T) {
+	var tests = testCases{
+		{"TestInt", `{{$v := toUint64 .V }}{{typeOf $v}}-{{$v}}`, "uint64-1", map[string]any{"V": 1}},
+		{"TestInt32", `{{$v := toUint64 .V }}{{typeOf $v}}-{{$v}}`, "uint64-1", map[string]any{"V": int32(1)}},
+		{"TestFloat64", `{{$v := toUint64 .V }}{{typeOf $v}}-{{$v}}`, "uint64-1", map[string]any{"V": float64(1.42)}},
+		{"TestBool", `{{$v := toUint64 .V }}{{typeOf $v}}-{{$v}}`, "uint64-1", map[string]any{"V": true}},
+		{"TestString", `{{$v := toUint64 .V }}{{typeOf $v}}-{{$v}}`, "uint64-1", map[string]any{"V": "1"}},
 	}
 
 	runTestCases(t, tests)

--- a/sprout.go
+++ b/sprout.go
@@ -149,9 +149,12 @@ func FuncMap(opts ...FunctionHandlerOption) template.FuncMap {
 	fnHandler.funcMap["sha256sum"] = fnHandler.Sha256sum
 	fnHandler.funcMap["adler32sum"] = fnHandler.Adler32sum
 	fnHandler.funcMap["toString"] = fnHandler.ToString
-	fnHandler.funcMap["toInt64"] = fnHandler.ToInt64
 	fnHandler.funcMap["toInt"] = fnHandler.ToInt
+	fnHandler.funcMap["toInt64"] = fnHandler.ToInt64
+	fnHandler.funcMap["toUint"] = fnHandler.ToUint
+	fnHandler.funcMap["toUint64"] = fnHandler.ToUint64
 	fnHandler.funcMap["toFloat64"] = fnHandler.ToFloat64
+	fnHandler.funcMap["toBool"] = fnHandler.ToBool
 	fnHandler.funcMap["seq"] = fnHandler.Seq
 	fnHandler.funcMap["toOctal"] = fnHandler.ToOctal
 	fnHandler.funcMap["toDuration"] = fnHandler.ToDuration


### PR DESCRIPTION
## Description
This pull request introduces three new functions `toBool`, `toUint` and `toUint64` to the conversion group

## Changes
- New functions: `toBool`, `toUint` and `toUint64`
- All conversion function are documented on https://docs.atom.codes/sprout

## Fixes https://github.com/Masterminds/sprig/issues/258, https://github.com/Masterminds/sprig/pull/307

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.
