### PR TITLE
fix: timezone leak in to date method

### DIFF
--- a/conversion_functions_test.go
+++ b/conversion_functions_test.go
@@ -135,7 +135,7 @@ func TestToDuration(t *testing.T) {
 
 func TestMustToDate(t *testing.T) {
 	var tests = mustTestCases{
-		{testCase{"TestDate", `{{$v := mustToDate "2006-01-02" .V }}{{typeOf $v}}-{{$v}}`, "time.Time-2024-05-09 00:00:00 +0000 UTC", map[string]any{"V": "2024-05-09"}}, ""},
+		{testCase{"TestDate", `{{$v := mustToDate "2006-01-02 15:04:05 MST" .V }}{{typeOf $v}}-{{$v}}`, "time.Time-2024-05-09 00:00:00 +0000 UTC", map[string]any{"V": "2024-05-09 00:00:00 UTC"}}, ""},
 		{testCase{"TestInvalidValue", `{{$v := mustToDate "2006-01-02" .V }}{{typeOf $v}}-{{$v}}`, "", map[string]any{"V": ""}}, "cannot parse \"\" as \"2006\""},
 		{testCase{"TestInvalidLayout", `{{$v := mustToDate "invalid" .V }}{{typeOf $v}}-{{$v}}`, "", map[string]any{"V": "2024-05-09"}}, "cannot parse \"2024-05-09\" as \"invalid\""},
 	}


### PR DESCRIPTION
## Description
This pull request resolve issue when run test locally on an other timezone than UTC.

- Fix the `TestMustToDate` to enforce UTC

## Fixes #41 

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.

## Additional Information
This raise a point to missing management of timezone in lib
