### PR TITLE
docs: add documentation for backward compatibilities

### DIFF
--- a/SPRIG_TO_SPROUT_CHANGES_NOTES.md
+++ b/SPRIG_TO_SPROUT_CHANGES_NOTES.md
@@ -99,3 +99,11 @@ Methods that previously caused a panic in Sprig :
 ```go
 {{ $dict | dig "a" "b" }} // Output: 2
 ```
+
+## ToCamelCase / ToPascalCase
+- **Sprig**: The `toCamelCase` return value are in PascalCase. No `toPascalCase` function is available.
+- **Sprout**: The `toCamelCase` function returns camelCase strings, while the `toPascalCase` function returns PascalCase strings.
+
+## Merge / MergeOverwrite
+- **Sprig**: The `merge` and `mergeOverwrite` functions does dereferencing when second value are the default golang value (example: `0` for int).
+- **Sprout**: The `merge` and `mergeOverwrite` functions does not dereference and keep the second value as is (example: `0` for int).

--- a/numeric_functions.go
+++ b/numeric_functions.go
@@ -237,7 +237,7 @@ func (fh *FunctionHandler) DivInt(values ...any) int64 {
 func (fh *FunctionHandler) Divf(values ...any) any {
 	//FIXME:  Special manipulation to force float operation
 	// This is a workaround to ensure that the result is a float to allow
-	// BACKWARD COMPATIBILITY with previous versions of Sprig.
+	// BACKWARDS COMPATIBILITY with previous versions of Sprig.
 	if len(values) > 0 {
 		if _, ok := values[0].(float64); !ok {
 			values[0] = cast.ToFloat64(values[0])

--- a/sprig_backward_compatibility.go
+++ b/sprig_backward_compatibility.go
@@ -5,41 +5,9 @@ import (
 	ttemplate "text/template"
 )
 
-// HermeticTxtFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
-func HermeticTxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
-	r := TxtFuncMap(opts...)
-	for _, name := range nonhermeticFunctions {
-		delete(r, name)
-	}
-	return r
-}
-
-// HermeticHtmlFuncMap returns an 'html/template'.Funcmap with only repeatable functions.
-func HermeticHtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
-	r := HtmlFuncMap(opts...)
-	for _, name := range nonhermeticFunctions {
-		delete(r, name)
-	}
-	return r
-}
-
-// TxtFuncMap returns a 'text/template'.FuncMap
-func TxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
-	return ttemplate.FuncMap(FuncMap(opts...))
-}
-
-// HtmlFuncMap returns an 'html/template'.Funcmap
-func HtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
-	return htemplate.FuncMap(FuncMap(opts...))
-}
-
-// GenericFuncMap returns a copy of the basic function map as a map[string]interface{}.
-func GenericFuncMap(opts ...FunctionHandlerOption) map[string]interface{} {
-	return FuncMap(opts...)
-}
-
 // These functions are not guaranteed to evaluate to the same result for given input, because they
 // refer to the environment or global state.
+// FOR BACKWARDS COMPATIBILITY ONLY
 var nonhermeticFunctions = []string{
 	// Date functions
 	"date",
@@ -63,4 +31,52 @@ var nonhermeticFunctions = []string{
 
 	// Network
 	"getHostByName",
+}
+
+// HermeticTxtFuncMap returns a 'text/template'.FuncMap with only repeatable functions.
+// It provides backward compatibility with sprig.FuncMap and integrates
+// additional configured functions.
+// FOR BACKWARDS COMPATIBILITY ONLY
+func HermeticTxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
+	r := TxtFuncMap(opts...)
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// HermeticHtmlFuncMap returns an 'html/template'.Funcmap with only repeatable functions.
+// It provides backward compatibility with sprig.FuncMap and integrates
+// additional configured functions.
+// FOR BACKWARDS COMPATIBILITY ONLY
+func HermeticHtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
+	r := HtmlFuncMap(opts...)
+	for _, name := range nonhermeticFunctions {
+		delete(r, name)
+	}
+	return r
+}
+
+// TxtFuncMap returns a 'text/template'.FuncMap
+// It provides backward compatibility with sprig.FuncMap and integrates
+// additional configured functions.
+// FOR BACKWARDS COMPATIBILITY ONLY
+func TxtFuncMap(opts ...FunctionHandlerOption) ttemplate.FuncMap {
+	return ttemplate.FuncMap(FuncMap(opts...))
+}
+
+// HtmlFuncMap returns an 'html/template'.Funcmap
+// It provides backward compatibility with sprig.FuncMap and integrates
+// additional configured functions.
+// FOR BACKWARDS COMPATIBILITY ONLY
+func HtmlFuncMap(opts ...FunctionHandlerOption) htemplate.FuncMap {
+	return htemplate.FuncMap(FuncMap(opts...))
+}
+
+// GenericFuncMap returns a copy of the basic function map as a map[string]interface{}.
+// It provides backward compatibility with sprig.FuncMap and integrates
+// additional configured functions.
+// FOR BACKWARDS COMPATIBILITY ONLY
+func GenericFuncMap(opts ...FunctionHandlerOption) map[string]interface{} {
+	return FuncMap(opts...)
 }


### PR DESCRIPTION
## Description
Few variables and methods don't have the mention for backward compatibility only. Also two changes of sprout has not clearly identified in the temporary list in **SPRIG_TO_SPROUT_CHANGES_NOTES.md** file. 

## Changes
- Add documentation line on backward functions
- Add changes on the SPRIG_TO_SPROUT_CHANGES_NOTES.md file

## Fixes #39 #40 

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information
_The file **SPRIG_TO_SPROUT_CHANGES_NOTES.md** will be moved in the future on the documentation site_ 
