### PR TITLE
docs: show conversion from duration to seconds

### DIFF
--- a/docs/functions/type-conversions.md
+++ b/docs/functions/type-conversions.md
@@ -205,6 +205,7 @@ Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m` and `h`.
 {{ (1000.0 * 1000.0) | toDuration }} // Output: 1ms
 {{ "1m" | toDuration }} // Output: 1m
 {{ "invalid" | toDuration }} // Output: 0s
+{{ (toDuration "1h30m").Seconds }} // Output: 5400
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
## Description
<!-- Please provide a clear and concise description of what the pull request achieves. Mention the issue it addresses (if applicable). -->

I use Go templates to produce machine-readable files, and one of the challenges I face is producing amounts of time as seconds and milliseconds. I want to write values like "5 minutes" or "30 seconds" for the benefit of file maintainers and have a computer do the math to turn them into numbers.

The `toDuration` function satisfies my use case and seems valuable to show in the documentation.

## Changes
<!--
- Detail the changes you have introduced.
- Highlight any new functionality.
-->

One more example for the `toDuration` function.

## Fixes <!-- #issueNumber -->

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information
<!-- Any additional information regarding this pull request. -->

This example matches this test: https://github.com/go-sprout/sprout/blob/aca5c32cd0f8340e64998aa718dee2b3564717d4/conversion_functions_test.go#L130
