### PR TITLE
fix: default logger have a bad init

### DIFF
--- a/sprout.go
+++ b/sprout.go
@@ -2,6 +2,7 @@ package sprout
 
 import (
 	"log/slog"
+	"os"
 )
 
 // HandlerOption[Handler] defines a type for functional options that configure
@@ -30,7 +31,7 @@ func New(opts ...HandlerOption[*DefaultHandler]) *DefaultHandler {
 	dh := &DefaultHandler{
 		ErrHandling: ErrHandlingReturnDefaultValue,
 		errChan:     make(chan error),
-		logger:      slog.New(&slog.TextHandler{}),
+		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		registries:  make([]Registry, 0),
 
 		cachedFuncsMap:   make(FunctionMap),


### PR DESCRIPTION
## Description
The default logger aren't initialized correctly causing crash when using the default logger without opts.

## Changes
- The default logger will now print on `stdout`

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.
