### PR TITLE
fix: logger aren't accessible due to duplicated pointer

### DIFF
--- a/docs/advanced/how-to-create-a-registry.md
+++ b/docs/advanced/how-to-create-a-registry.md
@@ -32,7 +32,7 @@ import (
 
 // OwnRegistry struct implements the Registry interface, embedding the Handler to access shared functionalities.
 type OwnRegistry struct {
-  handler *sprout.Handler // Embedding Handler for shared functionality
+  handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry initializes and returns a new instance of your registry.
@@ -47,7 +47,7 @@ func (or *OwnRegistry) Uid() string {
 
 // LinkHandler connects the Handler to your registry, enabling runtime functionalities.
 func (or *OwnRegistry) LinkHandler(fh sprout.Handler) error {
-  or.handler = &fh
+  or.handler = fh
   return nil
 }
 

--- a/registry/_example/_example.go
+++ b/registry/_example/_example.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ExampleRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -21,6 +21,6 @@ func (or *ExampleRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (or *ExampleRegistry) LinkHandler(fh registry.Handler) {
-	or.handler = &fh
+	or.handler = fh
 	return nil
 }

--- a/registry/backward/backward.go
+++ b/registry/backward/backward.go
@@ -26,7 +26,7 @@ import (
 )
 
 type BackwardCompatibilityRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -41,7 +41,7 @@ func (bcr *BackwardCompatibilityRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (bcr *BackwardCompatibilityRegistry) LinkHandler(fh sprout.Handler) error {
-	bcr.handler = &fh
+	bcr.handler = fh
 	return nil
 }
 

--- a/registry/checksum/checksum.go
+++ b/registry/checksum/checksum.go
@@ -3,7 +3,7 @@ package checksum
 import "github.com/go-sprout/sprout"
 
 type ChecksumRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of the checksum registry.
@@ -18,7 +18,7 @@ func (cr *ChecksumRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (cr *ChecksumRegistry) LinkHandler(fh sprout.Handler) error {
-	cr.handler = &fh
+	cr.handler = fh
 	return nil
 }
 

--- a/registry/conversion/conversion.go
+++ b/registry/conversion/conversion.go
@@ -3,7 +3,7 @@ package conversion
 import "github.com/go-sprout/sprout"
 
 type ConversionRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of conversion registry.
@@ -18,7 +18,7 @@ func (or *ConversionRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (or *ConversionRegistry) LinkHandler(fh sprout.Handler) error {
-	or.handler = &fh
+	or.handler = fh
 	return nil
 }
 

--- a/registry/crypto/crypto.go
+++ b/registry/crypto/crypto.go
@@ -7,7 +7,7 @@ import (
 )
 
 type CryptoRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // DSAKeyFormat stores the format for DSA keys.
@@ -60,7 +60,7 @@ func (ch *CryptoRegistry) Uid() string {
 }
 
 func (ch *CryptoRegistry) LinkHandler(fh sprout.Handler) error {
-	ch.handler = &fh
+	ch.handler = fh
 	return nil
 }
 

--- a/registry/encoding/encoding.go
+++ b/registry/encoding/encoding.go
@@ -3,7 +3,7 @@ package encoding
 import "github.com/go-sprout/sprout"
 
 type EncodingRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of conversion registry.
@@ -18,7 +18,7 @@ func (or *EncodingRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (or *EncodingRegistry) LinkHandler(fh sprout.Handler) error {
-	or.handler = &fh
+	or.handler = fh
 	return nil
 }
 

--- a/registry/env/env.go
+++ b/registry/env/env.go
@@ -3,7 +3,7 @@ package env
 import "github.com/go-sprout/sprout"
 
 type EnvironmentRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of env registry.
@@ -18,7 +18,7 @@ func (or *EnvironmentRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (or *EnvironmentRegistry) LinkHandler(fh sprout.Handler) error {
-	or.handler = &fh
+	or.handler = fh
 	return nil
 }
 

--- a/registry/filesystem/filesystem.go
+++ b/registry/filesystem/filesystem.go
@@ -3,7 +3,7 @@ package filesystem
 import "github.com/go-sprout/sprout"
 
 type FileSystemRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of filesystem registry.
@@ -18,7 +18,7 @@ func (fsr *FileSystemRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (fsr *FileSystemRegistry) LinkHandler(fh sprout.Handler) error {
-	fsr.handler = &fh
+	fsr.handler = fh
 	return nil
 }
 

--- a/registry/maps/maps.go
+++ b/registry/maps/maps.go
@@ -3,7 +3,7 @@ package maps
 import "github.com/go-sprout/sprout"
 
 type MapsRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of maps registry.
@@ -18,7 +18,7 @@ func (mr *MapsRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (mr *MapsRegistry) LinkHandler(fh sprout.Handler) error {
-	mr.handler = &fh
+	mr.handler = fh
 	return nil
 }
 

--- a/registry/numeric/numeric.go
+++ b/registry/numeric/numeric.go
@@ -15,7 +15,7 @@ import "github.com/go-sprout/sprout"
 type numericOperation func(float64, float64) float64
 
 type NumericRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of numeric registry.
@@ -30,7 +30,7 @@ func (nr *NumericRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (nr *NumericRegistry) LinkHandler(fh sprout.Handler) error {
-	nr.handler = &fh
+	nr.handler = fh
 	return nil
 }
 

--- a/registry/random/random.go
+++ b/registry/random/random.go
@@ -53,7 +53,7 @@ func init() {
 }
 
 type RandomRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of regexp registry.
@@ -68,7 +68,7 @@ func (rr *RandomRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (rr *RandomRegistry) LinkHandler(fh sprout.Handler) error {
-	rr.handler = &fh
+	rr.handler = fh
 	return nil
 }
 

--- a/registry/reflect/reflect.go
+++ b/registry/reflect/reflect.go
@@ -3,7 +3,7 @@ package reflect
 import "github.com/go-sprout/sprout"
 
 type ReflectRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of reflect registry.
@@ -18,7 +18,7 @@ func (rr *ReflectRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (rr *ReflectRegistry) LinkHandler(fh sprout.Handler) error {
-	rr.handler = &fh
+	rr.handler = fh
 	return nil
 }
 

--- a/registry/regexp/regexp.go
+++ b/registry/regexp/regexp.go
@@ -3,7 +3,7 @@ package regexp
 import "github.com/go-sprout/sprout"
 
 type RegexpRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of regexp registry.
@@ -18,7 +18,7 @@ func (rr *RegexpRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (rr *RegexpRegistry) LinkHandler(fh sprout.Handler) error {
-	rr.handler = &fh
+	rr.handler = fh
 	return nil
 }
 

--- a/registry/semver/semver.go
+++ b/registry/semver/semver.go
@@ -3,7 +3,7 @@ package semver
 import "github.com/go-sprout/sprout"
 
 type SemverRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -18,7 +18,7 @@ func (sr *SemverRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (sr *SemverRegistry) LinkHandler(fh sprout.Handler) error {
-	sr.handler = &fh
+	sr.handler = fh
 	return nil
 }
 

--- a/registry/slices/slices.go
+++ b/registry/slices/slices.go
@@ -3,7 +3,7 @@ package slices
 import "github.com/go-sprout/sprout"
 
 type SlicesRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -18,7 +18,7 @@ func (sr *SlicesRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (sr *SlicesRegistry) LinkHandler(fh sprout.Handler) error {
-	sr.handler = &fh
+	sr.handler = fh
 	return nil
 }
 

--- a/registry/std/std.go
+++ b/registry/std/std.go
@@ -3,7 +3,7 @@ package std
 import "github.com/go-sprout/sprout"
 
 type StdRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -18,7 +18,7 @@ func (sr *StdRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (sr *StdRegistry) LinkHandler(fh sprout.Handler) error {
-	sr.handler = &fh
+	sr.handler = fh
 	return nil
 }
 

--- a/registry/strings/strings.go
+++ b/registry/strings/strings.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 type StringsRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of strings registry.
@@ -88,7 +88,7 @@ func (sr *StringsRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (sr *StringsRegistry) LinkHandler(fh sprout.Handler) error {
-	sr.handler = &fh
+	sr.handler = fh
 	return nil
 }
 

--- a/registry/time/time.go
+++ b/registry/time/time.go
@@ -3,7 +3,7 @@ package time
 import "github.com/go-sprout/sprout"
 
 type TimeRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of conversion registry.
@@ -18,7 +18,7 @@ func (tr *TimeRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (tr *TimeRegistry) LinkHandler(fh sprout.Handler) error {
-	tr.handler = &fh
+	tr.handler = fh
 	return nil
 }
 

--- a/registry/uniqueid/uniqueid.go
+++ b/registry/uniqueid/uniqueid.go
@@ -3,7 +3,7 @@ package uniqueid
 import "github.com/go-sprout/sprout"
 
 type UniqueIDRegistry struct {
-	handler *sprout.Handler // Embedding Handler for shared functionality
+	handler sprout.Handler // Embedding Handler for shared functionality
 }
 
 // NewRegistry creates a new instance of your registry with the embedded Handler.
@@ -18,7 +18,7 @@ func (ur *UniqueIDRegistry) Uid() string {
 
 // LinkHandler links the handler to the registry at runtime.
 func (ur *UniqueIDRegistry) LinkHandler(fh sprout.Handler) error {
-	ur.handler = &fh
+	ur.handler = fh
 	return nil
 }
 


### PR DESCRIPTION
## Description
Handler are sent to registry over a double pointer causing inaccessible handler features. 

## Changes
- Use a pointer instead of double pointer.

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.