### PR TITLE
fix: sprigin camelcase needs to be the same (bugged) return

### DIFF
--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -46,7 +46,7 @@ var bc_registerSprigFuncs = sprout.FunctionAliasMap{
 	"add1":           []string{"add1f"},                         //! Deprecated: Should use add1 instead
 	"sub":            []string{"subf"},                          //! Deprecated: Should use sub instead
 	"toTitleCase":    []string{"title", "titlecase"},            //! Deprecated: Should use toTitleCase instead
-	"toCamelCase":    []string{"camel", "camelcase"},            //! Deprecated: Should use toCamelCase instead
+	"toPascalCase":   []string{"camelcase"},                     //! Deprecated: Should use toPascalCase instead
 	"toSnakeCase":    []string{"snake", "snakecase"},            //! Deprecated: Should use toSnakeCase instead
 	"toKebabCase":    []string{"kebab", "kebabcase"},            //! Deprecated: Should use toKebabCase instead
 	"swapCase":       []string{"swapcase"},                      //! Deprecated: Should use swapCase instead


### PR DESCRIPTION
## Description
In sprig, `camelcase` return a pascalcase. In Sprout we have both functions but as `sprigin` must be a no-breaking replacement, `camelcase` needs to still be "bugged" 😢 

## Changes
- Use alias to provide backward compatibility

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.