### PR TITLE
perf: reduce all memory fingerprint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,15 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         codecov_yml_path: .github/codecov.yml
+  compatibility:
+    name: Backward compatibility with Sprig v3 (template output)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Install Task
+      uses: arduino/setup-task@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Compare
+      run: task compare

--- a/SPRIG_TO_SPROUT_CHANGES_NOTES.md
+++ b/SPRIG_TO_SPROUT_CHANGES_NOTES.md
@@ -10,100 +10,35 @@ It will be updated to reflect changes in future versions of the library.
 
 This document will also assist in creating the migration guide when version 1.0 is ready.
 
+Any changes between the fork date and version 1.0.0 of the Sprout library not 
+migrated yet to the [Migration from Sprig](https://docs.atom.codes/sprout/migration-from-sprig) will be documented here.
 
-## Error Handling Enhancements
-### General Error Handling
-In Sprig, errors within certain functions cause a panic. 
-In contrast, Sprout opts for returning nil or an empty value, improving safety
-and predictability.
 
-**Old Behavior (Sprig)**: Triggers a panic on error
-```go
-if err != nil {
-  panic("deepCopy error: " + err.Error())
-}
-```
+## Templating Differences
+### Bugs fixed
+In Sprig, somes functions have bugs that have been fixed in Sprout:
 
-**New Behavior (Sprout)**: Returns nil or an empty value on error
-```go
-if err != nil {
-  return nil, err
-}
-```
-
-Methods that previously caused a panic in Sprig :
-- DeepCopy
-- MustDeepCopy
-- ToRawJson
-- Append
-- Prepend
-- Concat
-- Chunk
-- Uniq
-- Compact
-- Slice
-- Without
-- Rest
-- Initial
-- Reverse
-- First
-- Last
-- Has
-- Dig
-- RandAlphaNumeric
-- RandAlpha
-- RandAscii
-- RandNumeric
-- RandBytes
-
-## Function-Specific Changes
-
-### MustDeepCopy
-
-- **Sprig**: Accepts `nil` input, causing an internal panic.
-- **Sprout**: Returns `nil` if input is `nil`, avoiding panic.
-
-## Rand Functions
-
-- **Sprig**: Causes an internal panic if the length parameter is zero.
-- **Sprout**: Returns an empty string if the length is zero, ensuring stability.
-
-## DateAgo
-
-- **Sprig**: Does not support int32 and *time.Time; returns "0s".
-- **Sprout**: Supports int32 and *time.Time and returns the correct duration.
-
-## DateRound
-- **Sprig**: Returns a corrected duration in positive form, even for negative inputs.
-- **Sprout**: Accurately returns the duration, preserving the sign of the input.
-
-## Base32Decode / Base64Decode
-- **Sprig**: Decoding functions return the error string when the input is not a valid base64 encoded string.
-- **Sprout**: Decoding functions return an empty string if the input is not a valid base64 encoded string, simplifying error handling.
-
-## Dig 
-> Consider the example dictionary defined as follows:
-> ```go
-> dict := map[string]any{
->   "a": map[string]any{
->     "b": 2,
->   },
-> }
-> ```
-
-- **Sprig**: Previously, the `dig` function would return the last map in the access chain.
-```go
-{{ $dict | dig "a" "b" }} // Output: map[b:2]
-```
-- **Sprout**: Now, the `dig` function returns the final object in the chain, regardless of its type (map, array, string, etc.).
-```go
-{{ $dict | dig "a" "b" }} // Output: 2
-```
-
-## ToCamelCase / ToPascalCase
-- **Sprig**: The `toCamelCase` return value are in PascalCase. No `toPascalCase` function is available.
-- **Sprout**: The `toCamelCase` function returns camelCase strings, while the `toPascalCase` function returns PascalCase strings.
-
-## Merge / MergeOverwrite
-- **Sprig**: The `merge` and `mergeOverwrite` functions does dereferencing when second value are the default golang value (example: `0` for int).
-- **Sprout**: The `merge` and `mergeOverwrite` functions does not dereference and keep the second value as is (example: `0` for int).
+1. `{{ "foooboooooo" | abbrevboth 4 9 }}`
+  - Sprig: `fooobo...`
+  - Sprout: `...boo...`
+2. `{{ "FoO  bar" | camelcase }}` | `{{ "foo  bar" | camelcase }}`
+  - Sprig: `FoO Bar` | `Foo Bar`
+  - Sprout: `FoOBar` | `FooBar`
+3. `{{ camelcase "___complex__case_" }}` | `{{ camelcase "_camel_case" }}`
+  - Sprig: `___Complex_Case_` | `_CamelCase`
+  - Sprout: `ComplexCase` | `CamelCase`
+4. `{{ "foo  bar" | kebabcase }}`
+  - Sprig: `foo--bar`
+  - Sprout: `foo-bar`
+5. `{{ "foo  bar" | snakecase }}`
+  - Sprig: `foo__bar`
+  - Sprout: `foo_bar`
+6. `{{ snakecase "Duration2m3s" }}` | `{{ snakecase "Bld4Floor3rd" }}`
+  - Sprig: `duration_2m3s` | `bld4_floor_3rd`
+  - Sprout: `duration_2m_3s` | `bld_4floor_3rd`
+7. `{{ "foobar" | substr 0 -3 }}` | `{{ "foobar" | substr -3 6 }}`
+  - Sprig: `foobar` | `foobar`
+  - Sprout: `foo` | `bar`
+8. `{{ .duration | durationRound }}`
+  - Sprig: `0s` (only when not casted to `time.Duration` before, `{{ .duration | duration | durationRound }}` works as expected with `5s`)
+  - Sprout: `5s`

--- a/benchmarks/allFunctions.sprig.tmpl
+++ b/benchmarks/allFunctions.sprig.tmpl
@@ -1,212 +1,612 @@
-{{/* all.tpl: Testing Sprig template functions */}}
-
-Hello: {{ hello }}
-
-{{- $str := "Hello, World!" -}}
-{{- $dict := dict "key" "value" -}}
-{{- $list := list 1 2 3 -}}
-{{- $tuple := tuple 1 2 3 -}}
-{{- $set := set $dict "key2" "value2" -}}
-
-{{- $d := dict "one" 1 "two" 222222 -}}
-{{- $d2 := dict "one" 1 "two" 33333 -}}
-{{- $d3 := dict "one" 1 -}}
-{{- $d4 := dict "one" 1 "two" 4444 -}}
-
-
-{{/* Date functions */}}
-Ago: {{ago 5}}
-Date: {{date "Monday, 02 Jan 2006 15:04:05 MST" 0}}
-DateInZone: {{dateInZone "Monday, 02 Jan 2006 15:04:05 MST" 0 "UTC"}}
-DateModify: {{now | dateModify "-1.5h"}}
-Duration: {{duration "1h30m"}}
-DurationRound: {{durationRound "2h10m5s"}}
-HtmlDate: {{htmlDate "2006-01-02T15:04:05Z"}}
-HtmlDateInZone: {{htmlDateInZone "2006-01-02T15:04:05Z" "UTC"}}
-MustDateModify: {{now | mustDateModify "-1.5h"}}
-MustToDate: {{mustToDate "2006-01-02" "2017-12-31" | date "02/01/2006"}}
-Now: {{now}}
-ToDate: {{toDate "2006-01-02" "2017-12-31" | date "02/01/2006"}}
-UnixEpoch: {{now | unixEpoch}}
-
-{{/* String Functions */}}
-Abbrev: {{$str | abbrev 5}}
-AbbrevBoth: {{$str | abbrevboth 1 2}}
-Trunc: {{$str | trunc 5}}
-Trim: {{trim "   hello    "}}
-Upper: {{upper $str}}
-Lower: {{lower $str}}
-Title: {{title $str}}
-UnTitle: {{untitle $str}}
-Substr: {{substr 0 5 "hello world"}}
-Repeat: {{repeat 3 "hello"}}
-TrimAll: {{trimAll "$" "$5.00"}}
-TrimSuffix: {{trimSuffix "-" "hello-"}}
-TrimPrefix: {{trimPrefix "-" "-hello"}}
-NoSpace: {{nospace "Hello, World!"}}
-Initials: {{initials "Hello, World!"}}
-RandAlphaNum: {{randAlphaNum 10}}
-RandAlpha: {{randAlpha 10}}
-RandAscii: {{randAscii 10}}
-RandNumeric: {{randNumeric 10}}
-SwapCase: {{swapcase "Hello, World!"}}
-Shuffle: {{shuffle "Hello, World!"}}
-SnakeCase: {{snakecase "Hello, World!"}}
-CamelCase: {{camelcase "Hello, World!"}}
-KebabCase: {{kebabcase "Hello, World!"}}
-Wrap: {{"Hello, World!" | wrap 5}}
-WrapWith: {{"Hello, World!" | wrapWith 5 "!"}}
-Contains: {{contains $str "World"}}
-HasPrefix: {{hasPrefix $str "Hello"}}
-HasSuffix: {{hasSuffix $str "World"}}
-Quote: {{quote $str}}
-SQuote: {{squote $str}}
-Cat: {{cat "Hello" ", " "World!"}}
-Indent: {{"Hello, World!" | indent 5}}
-Nindent: {{"Hello, World!" | nindent 5}}
-Replace: {{$str | replace "World" "Sprig"}}
-Plural: {{2 | plural "apple" "apples"}}
-Sha1sum: {{sha1sum $str}}
-Sha256sum: {{sha256sum $str}}
-Adler32sum: {{adler32sum $str}}
-toString: {{toString 5}}
-
-Atoi: {{atoi "5"}}
-Int64: {{int64 5}}
-Int: {{int 5}}
-Float64: {{float64 5}}
-ToDecimal: {{toDecimal 8}}
-
-Split: {{"Hello, World!" | split ", "}}
-SplitList: {{"Hello, World!" | splitList ", "}}
-SplitN: {{"Hello, World!" | splitn ", " 1}}
-toStrings: {{list 1 2 3 | toStrings}}
-Until: {{until 5}}
-UntilStep: {{untilStep 3 6 2}}
-
-Add1: {{add1 5}}
-Add: {{add 5 10}}
-Sub: {{sub 10 5}}
-Mul: {{mul 5 10}}
-Div: {{div 10 5}}
-Mod: {{mod 10 5}}
-RandInt: {{randInt 5 10}}
-Add1f: {{add1f 5}}
-Addf: {{addf 5 10}}
-Subf: {{subf 10 5}}
-Mulf: {{mulf 5 10}}
-Divf: {{divf 10 5}}
-Biggest: {{biggest 5 10}}
-Max: {{max 5 10}}
-Min: {{min 5 10}}
-Ceil: {{ceil 5.5}}
-Floor: {{floor 5.5}}
-Round: {{round 123.555555 3}}
-Maxf: {{maxf 5.5 10.5}}
-Minf: {{minf 5.5 10.5}}
-
-Join: {{list "Hello" "World!" | join ", "}}
-SortAlpha: {{list "Hello" "World" "from" "Sprig" | sortAlpha}}
-
-{{/* Default Functions */}}
-{{- $defaultVal := "defaultValue" -}}
-Default: {{default "DefaultValue" $defaultVal}}
-Empty: {{empty ""}}
-Coal: {{coalesce "" "Hello, World!"}}
-All: {{all "" "Hello, World!"}}
-Any: {{any "" "Hello, World!"}}
-Compact: {{list 1 "a" "foo" "" | compact}}
-MustCompact: {{list 1 "a" "foo" "" | mustCompact}}
-FromJson: {{fromJson "{\"key\": \"value\"}"}}
-MustFromJson: {{mustFromJson "{\"key\": \"value\"}"}}
-ToJson: {{toJson $dict}}
-MustToJson: {{mustToJson $dict}}
-ToPrettyJson: {{toPrettyJson $dict}}
-ToRawJson: {{toRawJson $dict}}
-Ternary: {{true | ternary "true" "false"}}
-DeepCopy: {{deepCopy $dict}}
-MustDeepCopy: {{mustDeepCopy $dict}}
-
-TypeOf: {{typeOf 5}}
-TypeIs: {{5 | typeIs "int"}}
-TypeIsLike: {{5 | typeIsLike "int"}}
-KindOf: {{kindOf 5}}
-KindIs: {{5 | kindIs "int"}}
-DeepEqual: {{deepEqual 5 5}}
-
-
-{{/* OS Functions */}}
-Env: {{env "PATH"}}
-Expandenv: {{expandenv "$PATH"}}
-GetHostByName: {{getHostByName "localhost"}}
-Base Path: {{base "/path/to/file.txt"}}
-Dir: {{dir "/path/to/file.txt"}}
-Ext: {{ext "/path/to/file.txt"}}
-Clean: {{clean "/path/to/file.txt"}}
-IsAbs: {{isAbs "/path/to/file.txt"}}
-
-OsBase: {{osBase "/path/to/file.txt"}}
-OsDir: {{osDir "/path/to/file.txt"}}
-OsExt: {{osExt "/path/to/file.txt"}}
-OsClean: {{osClean "/path/to/file.txt"}}
-OsIsAbs: {{osIsAbs "/path/to/file.txt"}}
-
-{{/* Encoding Functions */}}
-Base64Encode: {{b64enc "Hello, World!"}}
-Base64Decode: {{b64dec "SGVsbG8sIFdvcmxkIQ=="}}
-Base32Encode: {{b32enc "Hello, World!"}}
-Base32Decode: {{b32dec "JBSWY3DPEBLW64TMMQQQ===="}}
-
-{{/* Data Struct Functions */}}
-Tuple: {{tuple 1 2 3}}
-List: {{list 1 2 3}}
-Dict: {{dict "key" "value"}}
-Get: {{get $dict "key"}}
-Set: {{set $dict "key" "newValue"}}
-Unset: {{unset $dict "key"}}
-hasKey: {{hasKey $dict "key"}}
-Pluck: {{pluck "two" $d $d2 $d3 $d4}}
-Keys: {{keys $dict}}
-Pick: {{pick $dict "key"}}
-Omit: {{omit $dict "key"}}
-Merge: {{merge $dict (dict "key2" "value2")}}
-MergeOverwrite: {{mergeOverwrite $dict (dict "key" "value2")}}
-Values: {{values $dict}}
-Append: {{append (list 1 2) 3}}
-Prepend: {{prepend (list 2 3) 1}}
-First: {{first (list 1 2 3)}}
-Rest: {{rest (list 1 2 3)}}
-Last: {{last (list 1 2 3)}}
-Initial: {{initial (list 1 2 3)}}
-Reverse: {{reverse (list 1 2 3)}}
-Uniq: {{uniq (list 1 2 2 3)}}
-Without: {{without (list 1 2 3) 2}}
-Has: {{hasKey $dict "key"}}
-Slice: {{slice (list 1 2 3) 1 2}}
-Concat: {{concat (list 1 2) (list 3 4)}}
-Dig: {{ dig "b" "a" (dict "a" 1 "b" (dict "a" 2)) }}
-Chunk: {{list 1 2 3 4 5 | chunk 2}}
-
-{{/* Crypt Functions */}}
-Bcrypt: {{bcrypt "Hello, World!"}}
-Htpasswd: {{htpasswd "myUser" "myPassword"}}
-genPrivateKey: {{genPrivateKey "rsa"}}
-derivePassword: {{derivePassword 1 "long" "password" "user" "example.com"}}
-RandBytes: {{randBytes 10}}
-
-UUIDv4: {{uuidv4}}
-Semver: {{semver "1.2.3"}}
-SemverCompare: {{semverCompare "1.2.3" "1.2.4"}}
-
-{{/* Regex Functions */}}
-RegexMatch: {{regexMatch "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$" "test@acme.com"}}
-RegexFindAll: {{regexFindAll "[2,4,6,8]" "123456789" -1}}
-RegexFind: {{regexFind "[a-zA-Z][1-9]" "abcd1234"}}
-RegexReplaceAll: {{regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"}}
-RegexReplaceAllLiteral: {{regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}"}}
-RegexSplit: {{regexSplit "z+" "pizza" -1}}
-RegexQuoteMeta: {{regexQuoteMeta "1.2.3"}}
-
-{{/* URL Functions */}}
-UrlParse: {{index ( urlParse "proto://auth@host:80/path?query#fragment" ) "host" }}
-UrlJoin: {{urlJoin (dict "fragment" "fragment" "host" "host:80" "path" "/path" "query" "query" "scheme" "proto")}}
+{{ urlParse "https://example.com" | urlJoin }}
+{{ urlParse "https://example.com/path" | urlJoin }}
+{{ urlParse "https://user:pass@example.com/path?query=1" | urlJoin }}
+{{sha1sum ""}}
+{{sha1sum "a"}}
+{{sha1sum "hello world"}}
+{{sha256sum ""}}
+{{sha256sum "a"}}
+{{sha256sum "hello world"}}
+{{adler32sum ""}}
+{{adler32sum "a"}}
+{{adler32sum "hello world"}}
+{{$v := int .string }}{{kindOf $v}}-{{$v}}
+{{$v := int .float }}{{kindOf $v}}-{{$v}}
+{{$v := int .bool }}{{kindOf $v}}-{{$v}}
+{{$v := int64 .string }}{{typeOf $v}}-{{$v}}
+{{$v := int64 .float }}{{typeOf $v}}-{{$v}}
+{{$v := int64 .int }}{{typeOf $v}}-{{$v}}
+{{$v := int64 .bool }}{{typeOf $v}}-{{$v}}
+{{$v := float64 .string }}{{typeOf $v}}-{{$v}}
+{{$v := float64 .float }}{{typeOf $v}}-{{$v}}
+{{$v := float64 .int }}{{typeOf $v}}-{{$v}}
+{{$v := float64 .bool }}{{typeOf $v}}-{{$v}}
+{{$v := toDecimal .string }}{{typeOf $v}}-{{$v}}
+{{$v := toDecimal .float }}{{typeOf $v}}-{{$v}}
+{{$v := toDecimal .int }}{{typeOf $v}}-{{$v}}
+{{$v := toDecimal .bool }}{{typeOf $v}}-{{$v}}
+{{$v := toString .string }}{{typeOf $v}}-{{$v}}
+{{$v := toString .int }}{{typeOf $v}}-{{$v}}
+{{$v := toString .float }}{{typeOf $v}}-{{$v}}
+{{$v := toString .bool }}{{typeOf $v}}-{{$v}}
+{{$v := toString .objectrray }}{{typeOf $v}}-{{$v}}
+{{$v := toString .time }}{{typeOf $v}}-{{$v}}
+{{$v := toString .duration }}{{typeOf $v}}-{{$v}}
+{{$v := toString .object }}{{typeOf $v}}-{{$v}}
+{{$v := toDate "2006-01-02" (.time | toString) }}{{typeOf $v}}-{{$v}}
+{{ "" | b64enc }}
+{{ "Hello World" | b64enc }}
+{{ "=" | b64enc }}
+{{ "" | b64dec }}
+{{ "SGVsbG8gV29ybGQ" | b64dec }}
+{{ "" | b32enc }}
+{{ "Hello World" | b32enc }}
+{{ "" | b32dec }}
+{{ "JBSWY3DPEBLW64TMMQ======" | b32dec }}
+{{ "JBSWY3DPEBLW64TMMQ" | b32dec }}
+{{ "" | fromJson }}
+{{ .json | fromJson }}
+{{ (.json | fromJson).foo }}
+{{ "" | toJson }}
+{{ .object | toJson }}
+{{ "" | toPrettyJson }}
+{{ .object | toPrettyJson }}
+{{ "" | toRawJson }}
+{{ .object | toRawJson }}
+{{ .json | mustFromJson }}
+{{ .object | mustToJson }}
+{{ .object | mustToPrettyJson }}
+{{ .object | mustToRawJson }}
+{{ env "" }}
+{{ env "NON_EXISTENT_ENV_VAR" }}
+{{ env "__SPROUT_TEST_ENV_KEY" }}
+{{ "__SPROUT_TEST_ENV_KEY" | env }}
+{{ expandenv "" }}
+{{ expandenv "Hey" }}
+{{ expandenv "$NON_EXISTENT_ENV_VAR" }}
+{{ expandenv "Hey $__SPROUT_TEST_ENV_KEY" }}
+{{ "Hey $__SPROUT_TEST_ENV_KEY" | expandenv }}
+{{ base "" }}
+{{ base "/" }}
+{{ base "/path/to/file" }}
+{{ base "/path/to/file.txt" }}
+{{ "/path/to/file.txt" | base }}
+{{ dir "" }}
+{{ dir "/" }}
+{{ dir "/path/to/file" }}
+{{ dir "/path/to/file.txt" }}
+{{ "/path/to/file.txt" | dir }}
+{{ ext "" }}
+{{ ext "/" }}
+{{ ext "/path/to/file" }}
+{{ ext "/path/to/file.txt" }}
+{{ "/path/to/file.txt" | ext }}
+{{ clean "" }}
+{{ clean "/" }}
+{{ clean "/path/to/file" }}
+{{ clean "/path/to/file.txt" }}
+{{ "/path/to/file.txt" | clean }}
+{{ clean "/path//to/file" }}
+{{ clean "/path/./to/file" }}
+{{ clean "/path/../to/file" }}
+{{ isAbs "" }}
+{{ isAbs "/" }}
+{{ isAbs "path/to/file" }}
+{{ isAbs "/path/to/file.txt" }}
+{{ "file.txt" | isAbs }}
+{{ floor 1.5 }}
+{{ floor 1 }}
+{{ floor -1.5 }}
+{{ floor -1 }}
+{{ floor 0 }}
+{{ floor 123 }}
+{{ floor "123" }}
+{{ floor 123.9999 }}
+{{ floor 123.0001 }}
+{{ ceil 1.5 }}
+{{ ceil 1 }}
+{{ ceil -1.5 }}
+{{ ceil -1 }}
+{{ ceil 0 }}
+{{ ceil 123 }}
+{{ ceil "123" }}
+{{ ceil 123.9999 }}
+{{ ceil 123.0001 }}
+{{ round 3.746 2 }}
+{{ round 3.746 2 0.5 }}
+{{ round 123.5555 3 }}
+{{ round "123.5555" 3 }}
+{{ round 123.500001 0 }}
+{{ round 123.49999999 0 }}
+{{ round 123.2329999 2 .3 }}
+{{ round 123.233 2 .3 }}
+{{ add }}
+{{ add 1 }}
+{{ add 1 2 3 4 5 6 7 8 9 10 }}
+{{ 10.1 | add 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9 }}
+{{ addf }}
+{{ addf 1 }}
+{{ addf 1 2 3 4 5 6 7 8 9 10 }}
+{{ 10.1 | addf 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9 }}
+{{ add1 -1 }}
+{{ add1f -1.0}}
+{{ add1 1 }}
+{{ add1 1.1 }}
+{{ add1f -1 }}
+{{ add1f -1.0}}
+{{ add1f 1 }}
+{{ add1f 1.1 }}
+{{ sub 1 1 }}
+{{ sub 1 2 }}
+{{ sub 1.1 1.1 }}
+{{ sub 1.1 2.2 }}
+{{ 3 | sub 14 }}
+{{ subf 1.1 1.1 }}
+{{ subf 1.1 2.2 }}
+{{ round (3 | subf 4.5 1) 1 }}
+{{ mul 1 1 }}
+{{ mul 1 2 }}
+{{ mul 1.1 1.1 }}
+{{ mul 1.1 2.2 }}
+{{ 3 | mul 14 }}
+{{ round (mulf 1.1 1.1) 2 }}
+{{ round (mulf 1.1 2.2) 2 }}
+{{ round (3.3 | mulf 14.4) 2 }}
+{{ div 1 1 }}
+{{ div 1 2 }}
+{{ div 1.1 1.1 }}
+{{ div 1.1 2.2 }}
+{{ 4 | div 5 }}
+{{ round (divf 1.1 1.1) 2 }}
+{{ round (divf 1.1 2.2) 2 }}
+{{ 2 | divf 5 4 }}
+{{ mod 10 4 }}
+{{ mod 10 3 }}
+{{ mod 10 2 }}
+{{ mod 10 1 }}
+{{ min 1 }}
+{{ min 1 "1" }}
+{{ min -1 0 1 }}
+{{ min 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 0 }}
+{{ minf 1 }}
+{{ minf 1 "1.1" }}
+{{ minf -1.4 .0 2.1 }}
+{{ minf .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 .1 .2 .3 .4 .5 .6 .7 .8 .9 .10}}
+{{ max 1 }}
+{{ max 1 "1" }}
+{{ max -1 0 1 }}
+{{ max 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 0 }}
+{{ maxf 1 }}
+{{ maxf 1.0 "1.1" }}
+{{ maxf -1.5 0 1.4 }}
+{{ maxf .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 }}
+{{typeIs "int" 42}}
+{{42 | typeIs "string"}}
+{{$var := 42}}{{typeIs "string" $var}}
+{{.object | typeIs "*reflect_test.testStruct"}}
+{{typeIsLike "int" 42}}
+{{42 | typeIsLike "string"}}
+{{$var := 42}}{{typeIsLike "string" $var}}
+{{.object | typeIsLike "*reflect_test.testStruct"}}
+{{.object | typeIsLike "reflect_test.testStruct"}}
+{{typeOf 42}}
+{{typeOf "42"}}
+{{$var := 42}}{{typeOf $var}}
+{{typeOf .object}}
+{{kindIs "int" 42}}
+{{42 | kindIs "string"}}
+{{$var := 42}}{{kindIs "string" $var}}
+{{.object | kindIs "ptr"}}
+{{kindOf 42}}
+{{kindOf "42"}}
+{{kindOf .object}}
+{{$var := 42}}{{kindOf $var}}
+{{kindOf .object}}
+{{kindOf .object}}
+{{deepEqual 42 42}}
+{{deepEqual "42" "42"}}
+{{deepEqual .object .object}}
+{{$a := 42}}{{$b := 42}}{{deepEqual $a $b}}
+{{deepEqual 42 32}}
+{{deepEqual 42 "42"}}
+{{$a := 42}}{{$b := deepCopy $a}}{{$b}}
+{{$a := "42"}}{{$b := deepCopy $a}}{{$b}}
+{{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+{{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+{{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+{{$a := 42}}{{$b := deepCopy $a}}{{$b}}
+{{$a := 42}}{{$b := deepCopy "42"}}{{$b}}
+{{$a := 42}}{{$b := deepCopy 42.0}}{{$b}}
+{{$b := deepCopy .object}}
+{{- $d := dict "a" 1 "b" 2 | deepCopy }}{{ values $d | sortAlpha | join "," }}
+{{- $d := dict "a" 1 "b" 2 | deepCopy }}{{ keys $d | sortAlpha | join "," }}
+{{- $one := dict "foo" (dict "bar" "baz") "qux" true -}}{{ deepCopy $one }}
+{{ regexFind "a(b+)" "aaabbb" }}
+{{ regexFindAll "a(b+)" "aaabbb" -1 }}
+{{ regexFindAll "a{2}" "aaaabbb" -1 }}
+{{ regexFindAll "a{2}" "none" -1 }}
+{{ regexMatch "^[a-zA-Z]+$" "Hello" }}
+{{ regexMatch "^[a-zA-Z]+$" "Hello123" }}
+{{ regexMatch "^[a-zA-Z]+$" "123" }}
+{{ regexSplit "a" "banana" -1 }}
+{{ regexSplit "a" "banana" 0 }}
+{{ regexSplit "a" "banana" 1 }}
+{{ regexSplit "a" "banana" 2 }}
+{{ regexSplit "a+" "banana" 1 }}
+{{ regexReplaceAll "a(x*)b" "-ab-axxb-" "T" }}
+{{ regexReplaceAll "a(x*)b" "-ab-axxb-" "$1" }}
+{{ regexReplaceAll "a(x*)b" "-ab-axxb-" "$1W" }}
+{{ regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W" }}
+{{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "T" }}
+{{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1" }}
+{{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1W" }}
+{{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}W" }}
+{{ regexQuoteMeta "Escaping $100? That's a lot." }}
+{{ regexQuoteMeta "1.2.3" }}
+{{ regexQuoteMeta "golang" }}
+{{ mustRegexFind "a(b+)" "aaabbb" }}
+{{ mustRegexFindAll "a(b+)" "aaabbb" -1 }}
+{{ mustRegexFindAll "a{2}" "aaaabbb" -1 }}
+{{ mustRegexFindAll "a{2}" "none" -1 }}
+{{ mustRegexMatch "^[a-zA-Z]+$" "Hello" }}
+{{ mustRegexMatch "^[a-zA-Z]+$" "Hello123" }}
+{{ mustRegexMatch "^[a-zA-Z]+$" "123" }}
+{{ mustRegexSplit "a" "banana" -1 }}
+{{ mustRegexSplit "a" "banana" 0 }}
+{{ mustRegexSplit "a" "banana" 1 }}
+{{ mustRegexSplit "a" "banana" 2 }}
+{{ mustRegexSplit "a+" "banana" 1 }}
+{{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "T" }}
+{{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "$1" }}
+{{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "$1W" }}
+{{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W" }}
+{{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "T" }}
+{{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1" }}
+{{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1W" }}
+{{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}W" }}
+{{ semver "1.0.0" }}
+{{ semver "1.0.0-alpha" }}
+{{ semver "1.0.0-alpha.1" }}
+{{ semver "1.0.0-alpha.1+build" }}
+{{ semverCompare "1.0.0" "1.0.0" }}
+{{ semverCompare "1.0.0" "1.0.1" }}
+{{ semverCompare "1.0.1" "1.0.0" }}
+{{ semverCompare "~1.0.0" "1.0.0" }}
+{{ semverCompare ">=1.0.0" "1.0.0-alpha" }}
+{{ semverCompare ">1.0.0-alpha" "1.0.0-alpha.1" }}
+{{ semverCompare "1.0.0-alpha.1" "1.0.0-alpha" }}
+{{ semverCompare "1.0.0-alpha.1" "1.0.0-alpha.1" }}
+{{ list }}
+{{ .string | list "ab" true 4 5 }}
+{{ append .array "a" }}
+{{ prepend .array "a" }}
+{{ concat .array (list 1 2 3) }}
+{{ list 4 5 | concat (list 1 2 3) }}
+{{ chunk 2 .array }}
+{{ uniq .array }}
+{{ compact .array }}
+{{ list 1 0 "" "hello" | compact }}
+{{ list "" "" | compact }}
+{{ list | compact }}
+{{ slice .array }}
+{{ slice .array 1 }}
+{{ slice .array 1 3 }}
+{{ slice .array 0 1 }}
+{{ .array | has "foo" }}
+{{ .array | has "a" }}
+{{ .array | has 1 }}
+{{ .array | has .nil }}
+{{ .array | has "nope" }}
+{{ without .array "a" }}
+{{ rest .array }}
+{{ initial .array }}
+{{ first .array }}
+{{ last .array }}
+{{ reverse .array }}
+{{ sortAlpha .array }}
+{{ .arrayCommas | splitList "," }}
+{{ toStrings .arrayCommas }}
+{{range $i, $e := until 5}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := until -5}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 0 5 1}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 3 6 1}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 0 -10 -2}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 3 0 1}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 3 99 0}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 3 99 -1}}({{$i}}{{$e}}){{end}}
+{{range $i, $e := untilStep 3 0 0}}({{$i}}{{$e}}){{end}}
+{{ mustAppend .array "a" }}
+{{ mustPrepend .array "a" }}
+{{ mustChunk 2 .array }}
+{{ mustUniq .array }}
+{{ mustCompact .array }}
+{{ mustSlice .array }}
+{{ mustSlice .array 1 }}
+{{ mustSlice .array 1 3 }}
+{{ mustSlice .array 0 1 }}
+{{ .array | mustHas "foo" }}
+{{ .array | mustHas "a" }}
+{{ .array | mustHas 1 }}
+{{ .array | mustHas .Nil }}
+{{ .array | mustHas "nope" }}
+{{ .array | mustHas 1 }}
+{{ mustWithout .array "a" }}
+{{ mustRest .array }}
+{{ mustInitial .array }}
+{{ mustFirst .array }}
+{{ mustLast .array }}
+{{ mustReverse .array }}
+{{hello}}
+{{default "default" ""}}
+{{default "default" "given"}}
+{{default "default" 42}}
+{{default "default" 2.42}}
+{{default "default" true}}
+{{default "default" false}}
+{{default "default" nil}}
+{{default "default" .nil}}
+{{"first" | default "default" "second"}}
+{{if empty ""}}1{{else}}0{{end}}
+{{if empty "given"}}1{{else}}0{{end}}
+{{if empty 42}}1{{else}}0{{end}}
+{{if empty .int}}1{{else}}0{{end}}
+{{if empty .string}}1{{else}}0{{end}}
+{{if empty 2.42}}1{{else}}0{{end}}
+{{if empty true}}1{{else}}0{{end}}
+{{if empty false}}1{{else}}0{{end}}
+{{if empty nil}}1{{else}}0{{end}}
+{{if empty .nil}}1{{else}}0{{end}}
+{{if all ""}}1{{else}}0{{end}}
+{{if all "given"}}1{{else}}0{{end}}
+{{if all 42 0 1}}1{{else}}0{{end}}
+{{ $two := 2 }}{{if all "" 0 nil $two }}1{{else}}0{{end}}
+{{ $two := 2 }}{{if all "" $two 0 0 0 }}1{{else}}0{{end}}
+{{ $two := 2 }}{{if all "" $two 3 4 5 }}1{{else}}0{{end}}
+{{if all }}1{{else}}0{{end}}
+{{if any ""}}1{{else}}0{{end}}
+{{if any "given"}}1{{else}}0{{end}}
+{{if any 42 0 1}}1{{else}}0{{end}}
+{{ $two := 2 }}{{if any "" 0 nil $two }}1{{else}}0{{end}}
+{{ $two := 2 }}{{if any "" $two 3 4 5 }}1{{else}}0{{end}}
+{{ $zero := 0 }}{{if any "" $zero 0 0 0 }}1{{else}}0{{end}}
+{{if any }}1{{else}}0{{end}}
+{{coalesce ""}}
+{{coalesce "given"}}
+{{ coalesce "" 0 nil 42 }}
+{{ $two := 2 }}{{ coalesce "" 0 nil $two }}
+{{ $two := 2 }}{{ coalesce "" $two 0 0 0 }}
+{{ $two := 2 }}{{ coalesce "" $two 3 4 5 }}
+{{ coalesce }}
+{{true | ternary "foo" "bar"}}
+{{ternary "foo" "bar" true}}
+{{false | ternary "foo" "bar"}}
+{{ternary "foo" "bar" false}}
+{{cat ""}}
+{{cat "given"}}
+{{cat 42}}
+{{cat 2.42}}
+{{cat true}}
+{{cat false}}
+{{cat nil}}
+{{cat .nil}}
+{{cat "first" "second"}}
+{{"first" | cat "second"}}
+{{$b := "b"}}{{"c" | cat "a" $b}}
+{{.string | cat "a" "b"}}
+{{ "" | nospace }}
+{{ " " | nospace }}
+{{ " foo" | nospace }}
+{{ "foo " | nospace }}
+{{ " foo " | nospace }}
+{{ " foo bar " | nospace }}
+{{ "" | trim }}
+{{ " " | trim }}
+{{ " foo" | trim }}
+{{ "foo " | trim }}
+{{ " foo " | trim }}
+{{ " foo bar " | trim }}
+{{ "" | trimAll "-" }}
+{{ "---------" | trimAll "-" }}
+{{ "foo" | trimAll "-" }}
+{{ "-f--o-o-" | trimAll "-" }}
+{{ "-f--o-o-" | trimAll "-o" }}
+{{ "" | trimPrefix "-" }}
+{{ "--" | trimPrefix "-" }}
+{{ "foo" | trimPrefix "-" }}
+{{ "-foo-" | trimPrefix "-" }}
+{{ "-foo-" | trimPrefix "-f" }}
+{{ "" | trimSuffix "-" }}
+{{ "--" | trimSuffix "-" }}
+{{ "foo" | trimSuffix "-" }}
+{{ "-foo-" | trimSuffix "-" }}
+{{ "-foo-" | trimSuffix "o-" }}
+{{ "" | contains "-" }}
+{{ "foo" | contains "o" }}
+{{ "foo" | contains "x" }}
+{{ "" | hasPrefix "-" }}
+{{ "foo" | hasPrefix "f" }}
+{{ "foo" | hasPrefix "o" }}
+{{ "" | hasSuffix "-" }}
+{{ "foo" | hasSuffix "o" }}
+{{ "foo" | hasSuffix "f" }}
+{{ "" | lower }}
+{{ "foo" | lower }}
+{{ "FOO" | lower }}
+{{ "" | upper }}
+{{ "foo" | upper }}
+{{ "FOO" | upper }}
+{{ "" | replace "-" "x" }}
+{{ "foo" | replace "o" "x" }}
+{{ "foo" | replace "x" "y" }}
+{{ "foo" | replace "o" "x" | replace "f" "y" }}
+{{ "" | repeat 3 }}
+{{ "foo" | repeat 3 }}
+{{ "foo" | repeat 0 }}
+{{ .nil | join "-" }}
+{{ .test | join "-" }}
+{{ .test | join "-" }}
+{{ .test | join "-" }}
+{{ .test | join "-" }}
+{{ "" | trunc 3 }}
+{{ "foooooo" | trunc 3 }}
+{{ "foobar" | trunc -3 }}
+{{ "foobar" | trunc -999 }}
+{{ "foobar" | trunc 0 }}
+{{ "" | abbrev 3 }}
+{{ "foo" | abbrev 5 }}
+{{ "foooooo" | abbrev 6 }}
+{{ "foobar" | abbrev 0 }}
+{{ "" | abbrevboth 3 5 }}
+{{ "foo" | abbrevboth 5 4 }}
+{{ "foooboooooo" | abbrevboth 4 9 }}
+{{ "foobar" | abbrevboth 0 0 }}
+{{ "" | initials }}
+{{ "f" | initials }}
+{{ "foo" | initials }}
+{{ "foo bar" | initials }}
+{{ "foo  bar" | initials }}
+{{ " Foo bar" | initials }}
+{{ 0 | plural "single" "many" }}
+{{ 1 | plural "single" "many" }}
+{{ 2 | plural "single" "many" }}
+{{ -1 | plural "single" "many" }}
+{{ "" | wrap 10 }}
+{{ wrap -1 "With a negative wrap." }}
+{{ "This is a long string that needs to be wrapped." | wrap 10 }}
+{{ "" | wrapWith 10 "\t" }}
+{{ "This is a long string that needs to be wrapped." | wrapWith 10 "\t" }}
+{{ "This is a long string that needs to be wrapped with a looooooooooooooooooooooooooooooooooooong word." | wrapWith 10 "\t" }}
+{{ "" | quote }}
+{{ quote .nil }}
+{{ "foo" | quote }}
+{{ "foo bar" | quote }}
+{{ "foo \"bar\"" | quote }}
+{{ "foo\nbar" | quote }}
+{{ "foo\\bar" | quote }}
+{{ "foo\\\"bar" | quote }}
+{{ quote "foo" "👍" }}
+{{ "" | squote }}
+{{ squote .nil }}
+{{ "foo" | squote }}
+{{ "foo bar" | squote }}
+{{ "foo 'bar'" | squote }}
+{{ "foo\nbar" | squote }}
+{{ "foo\\bar" | squote }}
+{{ "foo\\'bar" | squote }}
+{{ squote "foo" "👍" }}
+{{ "" | camelcase }}
+{{ "foo bar" | camelcase }}
+{{ "FoO  bar" | camelcase }}
+{{ "foo  bar" | camelcase }}
+{{ "foo_bar" | camelcase }}
+{{ "foo-bar" | camelcase }}
+{{ "foo-bar_baz" | camelcase }}
+{{ camelcase "___complex__case_" }}
+{{ camelcase "_camel_case" }}
+{{ camelcase "http_server" }}
+{{ camelcase "no_https" }}
+{{ camelcase "all" }}
+{{ "" | kebabcase }}
+{{ "foo bar" | kebabcase }}
+{{ "foo  bar" | kebabcase }}
+{{ "foo_bar" | kebabcase }}
+{{ "foo-bar" | kebabcase }}
+{{ "foo-bar_baz" | kebabcase }}
+{{ kebabcase "HTTPServer" }}
+{{ kebabcase "FirstName" }}
+{{ kebabcase "NoHTTPS" }}
+{{ kebabcase "GO_PATH" }}
+{{ kebabcase "GO PATH" }}
+{{ kebabcase "GO-PATH" }}
+{{ "" | snakecase }}
+{{ "foo bar" | snakecase }}
+{{ "foo  bar" | snakecase }}
+{{ "foo_bar" | snakecase }}
+{{ "foo-bar" | snakecase }}
+{{ "foo-bar_baz" | snakecase }}
+{{ snakecase "http2xx" }}
+{{ snakecase "HTTP20xOK" }}
+{{ snakecase "Duration2m3s" }}
+{{ snakecase "Bld4Floor3rd" }}
+{{ snakecase "FirstName" }}
+{{ snakecase "HTTPServer" }}
+{{ snakecase "NoHTTPS" }}
+{{ snakecase "GO_PATH" }}
+{{ snakecase "GO PATH" }}
+{{ snakecase "GO-PATH" }}
+{{ "" | title }}
+{{ "foo bar" | title }}
+{{ "foo  bar" | title }}
+{{ "foo_bar" | title }}
+{{ "foo-bar" | title }}
+{{ "foo-bar_baz" | title }}
+{{ "" | untitle }}
+{{ "Foo Bar" | untitle }}
+{{ "Foo  Bar" | untitle }}
+{{ "Foo_bar" | untitle }}
+{{ "Foo-Bar" | untitle }}
+{{ "Foo-Bar_baz" | untitle }}
+{{ "" | swapcase }}
+{{ "Foo Bar" | swapcase }}
+{{ "Foo  Bar" | swapcase }}
+{{ "Foo_bar" | swapcase }}
+{{ "Foo-Bar" | swapcase }}
+{{ "Foo-Bar_baz" | swapcase }}
+{{ $v := ("" | split "-") }}{{$v._0}}
+{{ $v := ("foo$bar$baz" | split "$") }}{{$v._0}} {{$v._1}} {{$v._2}}
+{{ $v := ("foo$bar$" | split "$") }}{{$v._0}} {{$v._1}} {{$v._2}}
+{{ $v := ("" | splitn "-" 3) }}{{$v._0}}
+{{ $v := ("foo$bar$baz" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
+{{ $v := ("foo$bar$" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
+{{ "" | substr 0 3 }}
+{{ "foobar" | substr 0 3 }}
+{{ "foobar" | substr 0 -3 }}
+{{ "foobar" | substr -3 6 }}
+{{ "" | indent 3 }}
+{{ "foo\nbar" | indent 3 }}
+{{ "foo\n bar" | indent 3 }}
+{{ "foo\n\tbar" | indent 3 }}
+{{ "" | nindent 3 }}
+{{ "foo\nbar" | nindent 3 }}
+{{ "foo\n bar" | nindent 3 }}
+{{ "foo\n\tbar" | nindent 3 }}
+{{ seq 0 1 3 }}
+{{ seq 0 3 10 }}
+{{ seq 3 3 2 }}
+{{ seq 3 -3 2 }}
+{{ seq }}
+{{ seq 0 4 }}
+{{ seq 5 }}
+{{ seq -5 }}
+{{ seq 0 }}
+{{ seq 0 1 2 3 }}
+{{ seq 0 -4 }}
+{{ .data265 | date "02 Jan 06 15:04 -0700" }}
+{{ .data266 | date "02 Jan 06 15:04 -0700" }}
+{{ .data267 | date "02 Jan 06 15:04 -0700" }}
+{{ .data268 | date "02 Jan 06 15:04 -0700" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data269 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data270 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data271 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data272 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data273 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data274 "UTC" }}
+{{ dateInZone "02 Jan 06 15:04 -0700" .data275 "invalid" }}
+{{ .duration | duration }}
+{{ .time | ago | substr 0 5 }}
+{{ now | date "02 Jan 06 15:04 -0700" }}
+{{ .time | unixEpoch }}
+{{ .time | dateModify "1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | dateModify "+1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | dateModify "-1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | dateModify "10m" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | dateModify "-10s" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | dateModify "zz" | date "02 Jan 06 15:04 -0700" }}
+{{ .duration | durationRound }}
+{{ .time | htmlDate }}
+{{ htmlDateInZone .time "UTC" }}
+{{ .time | mustDateModify "1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | mustDateModify "+1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | mustDateModify "-1h" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | mustDateModify "10m" | date "02 Jan 06 15:04 -0700" }}
+{{ .time | mustDateModify "-10s" | date "02 Jan 06 15:04 -0700" }}

--- a/benchmarks/allFunctionsAsSprig.sprout.tmpl
+++ b/benchmarks/allFunctionsAsSprig.sprout.tmpl
@@ -10,14 +10,6 @@
 {{adler32sum ""}}
 {{adler32sum "a"}}
 {{adler32sum "hello world"}}
-{{md5sum ""}}
-{{md5sum "a"}}
-{{md5sum "hello world"}}
-{{$v := toBool .string }}{{kindOf $v}}-{{$v}}
-{{$v := toBool .int }}{{kindOf $v}}-{{$v}}
-{{$v := toBool .float }}{{kindOf $v}}-{{$v}}
-{{$v := toBool .bool }}{{kindOf $v}}-{{$v}}
-{{$v := toBool .objectrray }}{{kindOf $v}}-{{$v}}
 {{$v := toInt .string }}{{kindOf $v}}-{{$v}}
 {{$v := toInt .float }}{{kindOf $v}}-{{$v}}
 {{$v := toInt .bool }}{{kindOf $v}}-{{$v}}
@@ -25,14 +17,6 @@
 {{$v := toInt64 .float }}{{typeOf $v}}-{{$v}}
 {{$v := toInt64 .int }}{{typeOf $v}}-{{$v}}
 {{$v := toInt64 .bool }}{{typeOf $v}}-{{$v}}
-{{$v := toUint .string }}{{kindOf $v}}-{{$v}}
-{{$v := toUint .float }}{{kindOf $v}}-{{$v}}
-{{$v := toUint .int }}{{kindOf $v}}-{{$v}}
-{{$v := toUint .bool }}{{kindOf $v}}-{{$v}}
-{{$v := toUint64 .string }}{{typeOf $v}}-{{$v}}
-{{$v := toUint64 .float }}{{typeOf $v}}-{{$v}}
-{{$v := toUint64 .int }}{{typeOf $v}}-{{$v}}
-{{$v := toUint64 .bool }}{{typeOf $v}}-{{$v}}
 {{$v := toFloat64 .string }}{{typeOf $v}}-{{$v}}
 {{$v := toFloat64 .float }}{{typeOf $v}}-{{$v}}
 {{$v := toFloat64 .int }}{{typeOf $v}}-{{$v}}
@@ -50,11 +34,6 @@
 {{$v := toString .duration }}{{typeOf $v}}-{{$v}}
 {{$v := toString .object }}{{typeOf $v}}-{{$v}}
 {{$v := toDate "2006-01-02" (.time | toString) }}{{typeOf $v}}-{{$v}}
-{{$v := toDuration .time }}{{typeOf $v}}-{{$v}}
-{{$v := toDuration .int }}{{typeOf $v}}-{{$v}}
-{{$v := toDuration .float }}{{typeOf $v}}-{{$v}}
-{{$v := toDuration .duration }}{{typeOf $v}}-{{$v}}
-{{ (toDuration "1h30m").Seconds }}
 {{ "" | base64Encode }}
 {{ "Hello World" | base64Encode }}
 {{ "=" | base64Encode }}
@@ -74,17 +53,10 @@
 {{ .object | toPrettyJson }}
 {{ "" | toRawJson }}
 {{ .object | toRawJson }}
-{{ "" | fromYaml }}
-{{ .yaml | fromYaml }}
-{{ (.yaml | fromYaml).foo }}
-{{ "" | toYaml }}
-{{ .yaml | toYaml }}
 {{ .json | mustFromJson }}
 {{ .object | mustToJson }}
 {{ .object | mustToPrettyJson }}
 {{ .object | mustToRawJson }}
-{{ .yaml | mustFromYaml }}
-{{ .object | mustToYaml }}
 {{ env "" }}
 {{ env "NON_EXISTENT_ENV_VAR" }}
 {{ env "__SPROUT_TEST_ENV_KEY" }}
@@ -192,7 +164,6 @@
 {{ mod 10 3 }}
 {{ mod 10 2 }}
 {{ mod 10 1 }}
-{{ mod 10 0 }}
 {{ min 1 }}
 {{ min 1 "1" }}
 {{ min -1 0 1 }}
@@ -251,11 +222,9 @@
 {{- $d := dict "a" 1 "b" 2 | deepCopy }}{{ keys $d | sortAlpha | join "," }}
 {{- $one := dict "foo" (dict "bar" "baz") "qux" true -}}{{ deepCopy $one }}
 {{ regexFind "a(b+)" "aaabbb" }}
-{{ regexFind "a(b+" "aaabbb" }}
 {{ regexFindAll "a(b+)" "aaabbb" -1 }}
 {{ regexFindAll "a{2}" "aaaabbb" -1 }}
 {{ regexFindAll "a{2}" "none" -1 }}
-{{ regexFindAll "a(b+" "aaabbb" -1 }}
 {{ regexMatch "^[a-zA-Z]+$" "Hello" }}
 {{ regexMatch "^[a-zA-Z]+$" "Hello123" }}
 {{ regexMatch "^[a-zA-Z]+$" "123" }}
@@ -549,30 +518,6 @@
 {{ toKebabCase "GO_PATH" }}
 {{ toKebabCase "GO PATH" }}
 {{ toKebabCase "GO-PATH" }}
-{{ "" | toPascalCase }}
-{{ "foo bar" | toPascalCase }}
-{{ "foo  bar" | toPascalCase }}
-{{ "foo_bar" | toPascalCase }}
-{{ "foo-bar" | toPascalCase }}
-{{ "foo-bar_baz" | toPascalCase }}
-{{ "" | toDotCase }}
-{{ "foo bar" | toDotCase }}
-{{ "foo  bar" | toDotCase }}
-{{ "foo_bar" | toDotCase }}
-{{ "foo-bar" | toDotCase }}
-{{ "foo-bar_baz" | toDotCase }}
-{{ "" | toPathCase }}
-{{ "foo bar" | toPathCase }}
-{{ "foo  bar" | toPathCase }}
-{{ "foo_bar" | toPathCase }}
-{{ "foo-bar" | toPathCase }}
-{{ "foo-bar_baz" | toPathCase }}
-{{ "" | toConstantCase }}
-{{ "foo bar" | toConstantCase }}
-{{ "foo  bar" | toConstantCase }}
-{{ "foo_bar" | toConstantCase }}
-{{ "foo-bar" | toConstantCase }}
-{{ "foo-bar_baz" | toConstantCase }}
 {{ "" | toSnakeCase }}
 {{ "foo bar" | toSnakeCase }}
 {{ "foo  bar" | toSnakeCase }}
@@ -614,12 +559,9 @@
 {{ $v := ("foo$bar$baz" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
 {{ $v := ("foo$bar$" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
 {{ "" | substr 0 3 }}
-{{ "" | substr -1 -4 }}
 {{ "foobar" | substr 0 3 }}
 {{ "foobar" | substr 0 -3 }}
 {{ "foobar" | substr -3 6 }}
-{{ "foobar" | substr -3 -1 }}
-{{ "foobar" | substr -3 -3 }}
 {{ "" | indent 3 }}
 {{ "foo\nbar" | indent 3 }}
 {{ "foo\n bar" | indent 3 }}

--- a/benchmarks/comparaison_test.go
+++ b/benchmarks/comparaison_test.go
@@ -2,10 +2,13 @@ package benchmarks_test
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 	"testing"
 	"text/template"
+	gotime "time"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-sprout/sprout"
@@ -31,78 +34,116 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var data = map[string]any{
+	"string":      "example string value",
+	"url":         "https://example.com",
+	"arrayCommas": "a,b,c",
+	"int":         123,
+	"float":       123.456,
+	"bool":        true,
+	"array":       []any{"a", "b", "c"},
+	"map":         map[string]any{"foo": "bar"},
+	"object":      struct{ Name string }{"example object"},
+	"func":        func() string { return "example function" },
+	"error":       fmt.Errorf("example error"),
+	"time":        gotime.Now(),
+	"duration":    5 * gotime.Second,
+	"channel":     make(chan any),
+	"json":        `{"foo": "bar"}`,
+	"yaml":        "foo: bar",
+	"nil":         nil,
+}
+
+func BenchmarkComparison(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+
+	b.Run("Sprig", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sprigBench()
+		}
+	})
+
+	b.Run("Sprout", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sproutBench("allFunctionsAsSprig.sprout.tmpl")
+		}
+	})
+}
+
+func BenchmarkAllSprout(b *testing.B) {
+	runtime.GOMAXPROCS(1)
+
+	b.Run("SproutWiothNewFeatures", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sproutBench("allFunctions.sprout.tmpl")
+		}
+	})
+}
+
 /**
  * BenchmarkSprig are the benchmarks for Sprig.
  * It is the same as SproutBench but with Sprig.
  */
-func BenchmarkSprig(b *testing.B) {
-	b.ResetTimer()
+func sprigBench() {
+	tmpl, err := template.New("allFunctions").Funcs(sprig.FuncMap()).ParseGlob("allFunctions.sprig.tmpl")
+	if err != nil {
+		panic(err)
+	}
 
-	for i := 0; i < b.N; i++ {
-		tmpl, err := template.New("allFunctions").Funcs(sprig.FuncMap()).ParseGlob("*.sprig.tmpl")
+	var buf bytes.Buffer
+	for _, t := range tmpl.Templates() {
+		err := tmpl.ExecuteTemplate(&buf, t.Name(), data)
 		if err != nil {
 			panic(err)
 		}
-
-		var buf bytes.Buffer
-		for _, t := range tmpl.Templates() {
-			err := tmpl.ExecuteTemplate(&buf, t.Name(), nil)
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		buf.Reset()
 	}
+
+	buf.Reset()
 }
 
 /**
  * BenchmarkSprout are the benchmarks for Sprout.
  */
-func BenchmarkSprout(b *testing.B) {
-	b.ResetTimer()
+func sproutBench(templatePath string) {
+	fnHandler := sprout.New(
+		sprout.WithLogger(slog.New(&slog.TextHandler{})),
+	)
 
-	for i := 0; i < b.N; i++ {
-		fnHandler := sprout.New(
-			sprout.WithLogger(slog.New(&slog.TextHandler{})),
-		)
+	_ = fnHandler.AddRegistries(
+		std.NewRegistry(),
+		uniqueid.NewRegistry(),
+		semver.NewRegistry(),
+		backward.NewRegistry(),
+		reflect.NewRegistry(),
+		time.NewRegistry(),
+		strings.NewRegistry(),
+		random.NewRegistry(),
+		checksum.NewRegistry(),
+		conversion.NewRegistry(),
+		numeric.NewRegistry(),
+		encoding.NewRegistry(),
+		regexp.NewRegistry(),
+		slices.NewRegistry(),
+		maps.NewRegistry(),
+		crypto.NewRegistry(),
+		filesystem.NewRegistry(),
+		env.NewRegistry(),
+	)
 
-		_ = fnHandler.AddRegistries(
-			std.NewRegistry(),
-			uniqueid.NewRegistry(),
-			semver.NewRegistry(),
-			backward.NewRegistry(),
-			reflect.NewRegistry(),
-			time.NewRegistry(),
-			strings.NewRegistry(),
-			random.NewRegistry(),
-			checksum.NewRegistry(),
-			conversion.NewRegistry(),
-			numeric.NewRegistry(),
-			encoding.NewRegistry(),
-			regexp.NewRegistry(),
-			slices.NewRegistry(),
-			maps.NewRegistry(),
-			crypto.NewRegistry(),
-			filesystem.NewRegistry(),
-			env.NewRegistry(),
-		)
+	tmpl, err := template.New("allFunctions").Funcs(fnHandler.Build()).ParseGlob(templatePath)
 
-		tmpl, err := template.New("allFunctions").Funcs(fnHandler.Build()).ParseGlob("*.sprout.tmpl")
+	if err != nil {
+		panic(err)
+	}
 
+	var buf bytes.Buffer
+	for _, t := range tmpl.Templates() {
+		err := tmpl.ExecuteTemplate(&buf, t.Name(), data)
 		if err != nil {
 			panic(err)
 		}
-
-		var buf bytes.Buffer
-		for _, t := range tmpl.Templates() {
-			err := tmpl.ExecuteTemplate(&buf, t.Name(), fnHandler)
-			if err != nil {
-				panic(err)
-			}
-		}
-		buf.Reset()
 	}
+	buf.Reset()
 }
 
 func TestCompareSprigAndSprout(t *testing.T) {
@@ -118,7 +159,7 @@ func TestCompareSprigAndSprout(t *testing.T) {
 		tmplSprig, err := template.New("compare").Funcs(sprig.FuncMap()).ParseFiles("compare.tmpl")
 		assert.NoError(t, err)
 
-		err = tmplSprig.ExecuteTemplate(&bufSprig, "compare.tmpl", nil)
+		err = tmplSprig.ExecuteTemplate(&bufSprig, "compare.tmpl", data)
 		assert.NoError(t, err)
 	}()
 
@@ -128,11 +169,11 @@ func TestCompareSprigAndSprout(t *testing.T) {
 		tmplSprout, err := template.New("compare").Funcs(sprigin.FuncMap()).ParseGlob("compare.tmpl")
 		assert.NoError(t, err)
 
-		err = tmplSprout.ExecuteTemplate(&bufSprout, "compare.tmpl", nil)
+		err = tmplSprout.ExecuteTemplate(&bufSprout, "compare.tmpl", data)
 		assert.NoError(t, err)
 	}()
 
 	wg.Wait()
-	// sprig is expected and sprout is actual
+	// sprig is expected (---) and sprout is actual (+++)
 	assert.Equal(t, bufSprig.String(), bufSprout.String())
 }

--- a/benchmarks/compare.tmpl
+++ b/benchmarks/compare.tmpl
@@ -1,220 +1,620 @@
-{{/* compare.tpl: Used to compare sprig to sprout */}}
+IMPORTANT NOTE:
 
-Hello: {{ hello }}
+This file is used to compare the output of the Sprig functions with the Sprout
+output to ensure no breaking changes are introduced. This is important to ensure
+that the Sprout functions are compatible with the Sprig functions.
 
-{{- $str := "Hello, World!" -}}
-{{- $dict := dict "key" "value" -}}
-{{- $list := list 1 2 3 -}}
-{{- $tuple := tuple 1 2 3 -}}
-{{- $set := set $dict "key2" "value2" -}}
-{{- $date := toDate "2006-01-02" "2017-12-31" -}}
+To test the compatibility, run the following command: `task compare`.
 
-{{- $d := dict "one" 1 "two" 222222 -}}
-{{- $d2 := dict "one" 1 "two" 33333 -}}
-{{- $d3 := dict "one" 1 -}}
-{{- $d4 := dict "one" 1 "two" 4444 -}}
+Somes entries are excluded from the comparison by comment `excluded due to fixed output in Sprig`,
+this is because the output of the function is fixed in Sprout due to bugs not fixed in Sprig.
 
-{{/* Date functions */}}
-Ago: {{ago $date }}
-Date: {{date "Monday, 02 Jan 2006 15:04:05 MST" 0}}
-DateInZone: {{dateInZone "Monday, 02 Jan 2006 15:04:05 MST" 0 "UTC"}}
-DateModify: {{$date | dateModify "-1.5h"}}
-Duration: {{duration "1h30m"}}
-DurationRound: {{durationRound "2h10m5s"}} | {{ durationRound "2400h10m5s" }}
-HtmlDate: {{htmlDate "2006-01-02T15:04:05Z"}}
-HtmlDateInZone: {{htmlDateInZone "2006-01-02T15:04:05Z" "UTC"}}
-MustDateModify: {{$date | mustDateModify "-1.5h"}}
-MustToDate: {{mustToDate "2006-01-02" "2017-12-31" | date "02/01/2006"}}
-Now: {{now | date "02/01/2006"}}
-ToDate: {{toDate "2006-01-02" "2017-12-31" | date "02/01/2006"}}
-UnixEpoch: {{$date | unixEpoch}}
-
-
-{{/* String Functions */}}
-Abbrev: {{$str | abbrev 5}}
-AbbrevBoth: {{$str | abbrevboth 1 2}}
-Trunc: {{$str | trunc 5}} | {{$str | trunc -5}}
-Trim: {{trim "   hello    "}}
-Upper: {{upper $str}}
-Lower: {{lower $str}}
-Title: {{title $str}}
-UnTitle: {{untitle $str}}
-Substr: {{substr 0 5 "hello world"}}
-Repeat: {{repeat 3 "hello"}}
-TrimAll: {{trimAll "$" "$5.00"}}
-TrimSuffix: {{trimSuffix "-" "hello-"}}
-TrimPrefix: {{trimPrefix "-" "-hello"}}
-NoSpace: {{nospace "Hello, World!"}}
-Initials: {{initials "Hello, World!"}}
-SwapCase: {{swapcase "Hello, World!"}}
-SnakeCase: {{snakecase "Hello, World!"}}
-CamelCase: {{camelcase "Hello, World!"}}
-KebabCase: {{kebabcase "Hello, World!"}}
-Wrap: {{"Hello, World!" | wrap 5}}
-WrapWith: {{"Hello World!" | wrapWith 10 "\\n"}}
-Contains: {{contains $str "World"}}
-HasPrefix: {{hasPrefix $str "Hello"}}
-HasSuffix: {{hasSuffix $str "World"}}
-Quote: {{quote $str}}
-SQuote: {{squote $str}}
-Cat: {{cat "Hello" ", " "World!"}}
-Indent: {{"Hello, World!" | indent 5}}
-Nindent: {{"Hello, World!" | nindent 5}}
-Replace: {{$str | replace "World" "Sprig"}}
-Plural: {{2 | plural "apple" "apples"}} | {{1 | plural "apple" "apples"}}
-Sha1sum: {{sha1sum $str}}
-Sha256sum: {{sha256sum $str}}
-Adler32sum: {{adler32sum $str}}
-toString: {{toString 5}}
-
-Atoi: {{atoi "5"}}
-Int64: {{int64 5}}
-Int: {{int 5}}
-Float64: {{float64 5}}
-ToDecimal: {{toDecimal "0777"}}
-
-Split: {{"Hello, World!" | split ", "}}
-SplitList: {{"Hello, World!" | splitList ", "}}
-SplitN: {{"Hello, World!" | splitn ", " 1}}
-toStrings: {{list 1 2 3 | toStrings}}
-Until: {{until 5}}
-UntilStep: {{untilStep 3 6 2}}
-
-Add1: {{add1 5}}
-Add: {{add 5 10}}
-Sub: {{sub 10 5}}
-Mul: {{mul 5 10}}
-Div: {{div 10 5}}
-Mod: {{mod 10 5}}
-Add1f: {{add1f 5}}
-Addf: {{addf 5 10}}
-Subf: {{subf 10 5}}
-Mulf: {{mulf 5 10}}
-Divf: {{divf 10 5}}
-Biggest: {{biggest 5 10}}
-Max: {{max 5 6 10}}
-Min: {{min 5 6 10}}
-Ceil: {{ceil 123.001}}
-Floor: {{floor 123.9999}}
-Round: {{round 123.555555 3}}
-Maxf: {{maxf 5.5 10.5}}
-Minf: {{minf 5.5 10.5}}
-Seq: {{seq 5}} | {{seq -3}} | {{seq 0 2}} | {{seq 2 -2}} | {{seq 0 2 10}} | {{seq 0 -2 -5}}
-
-Join: {{list "Hello" "World!" | join ", "}} | {{list 1  2 3 | join "+"}}
-SortAlpha: {{list "Hello" "World" "from" "Sprig" | sortAlpha}}
-
-{{/* Default Functions */}}
-{{- $defaultVal := "defaultValue" -}}
-Default: {{default "DefaultValue" $defaultVal}}
-Empty: {{empty ""}}
-Coal: {{coalesce "" "Hello, World!"}}
-All: {{all "" "Hello, World!"}}
-Any: {{any "" "Hello, World!"}}
-Compact: {{list 1 "a" "foo" "" | compact}}
-MustCompact: {{list 1 "a" "foo" "" | mustCompact}}
-FromJson: {{fromJson "{\"key\": \"value\"}"}}
-MustFromJson: {{mustFromJson "{\"key\": \"value\"}"}}
-ToJson: {{toJson $dict}}
-MustToJson: {{mustToJson $dict}}
-ToPrettyJson: {{toPrettyJson $dict}}
-ToRawJson: {{toRawJson $dict}}
-Ternary: {{true | ternary "true" "false"}}
-DeepCopy: {{deepCopy $dict}}
-MustDeepCopy: {{mustDeepCopy $dict}}
-
-TypeOf: {{typeOf 5}}
-TypeIs: {{5 | typeIs "int"}}
-TypeIsLike: {{5 | typeIsLike "int"}}
-KindOf: {{kindOf 5}}
-KindIs: {{5 | kindIs "int"}}
-DeepEqual: {{ deepEqual (list 1 2 3) (list 1 2 3) }}
-
-
-{{/* OS Functions */}}
-Env: {{env "PATH"}}
-Expandenv: {{expandenv "$PATH"}}
-Base Path: {{base "/path/to/file.txt"}}
-Dir: {{dir "/path/to/file.txt"}}
-Ext: {{ext "/path/to/file.txt"}}
-Clean: {{clean "/path/to/file.txt"}}
-IsAbs: {{isAbs "/path/to/file.txt"}}
-
-OsBase: {{osBase "/path/to/file.txt"}}
-OsDir: {{osDir "/path/to/file.txt"}}
-OsExt: {{osExt "/path/to/file.txt"}}
-OsClean: {{osClean "/path/to/file.txt"}}
-OsIsAbs: {{osIsAbs "/path/to/file.txt"}}
-
-{{/* Encoding Functions */}}
-Base64Encode: {{b64enc "Hello, World!"}}
-Base64Decode: {{b64dec "SGVsbG8sIFdvcmxkIQ=="}}
-Base32Encode: {{b32enc "Hello, World!"}}
-Base32Decode: {{b32dec "JBSWY3DPEBLW64TMMQQQ===="}}
-
-{{/* Data Struct Functions */}}
-Tuple: {{tuple 1 2 3}}
-List: {{list 1 2 3}}
-Dict: {{dict "key" "value"}}
-Get: {{get $dict "key"}}
-Set: {{set $dict "key" "newValue"}}
-Unset: {{unset $dict "key"}}
-has: {{has 4 (list 1 2 4)}}
-Pluck: {{pluck "two" $d $d2 $d3 $d4}}
-Keys: {{keys $dict}}
-Pick: {{pick $dict "key"}}
-Omit: {{omit $dict "key"}}
-Merge: {{merge $dict (dict "key2" "value2")}}
-MergeOverwrite: {{mergeOverwrite $dict (dict "key" "value2")}}
-Values: {{values $dict}}
-Append: {{append (list 1 2) 3}}
-Prepend: {{prepend (list 2 3) 1}}
-First: {{first (list 1 2 3)}}
-Rest: {{rest (list 1 2 3)}}
-Last: {{last (list 1 2 3)}}
-Initial: {{initial (list 1 2 3)}}
-Reverse: {{reverse (list 1 2 3)}}
-Uniq: {{uniq (list 1 2 2 3)}}
-Without: {{without (list 1 2 3) 2}} | {{without (list 1 2 3) 2 3}}
-HasKey: {{hasKey $dict "key"}}
-Slice: {{slice (list 1 2 3) 1 2}} | {{slice (list 1 2 3) 1}}
-Concat: {{concat (list 1 2) (list 3 4)}}
-# Incompatible with sprig
-# Dig: {{/* dig "b" "a" (dict "a" 1 "b" (dict "a" 2)) */}}
-Chunk: {{list 1 2 3 4 5 | chunk 2}}
-
-{{/* Crypt Functions */}}
-derivePassword: {{derivePassword 1 "long" "password" "user" "example.com"}}
-
-Semver: {{semver "1.2.3"}}
-SemverCompare: {{semverCompare "^1.2.0" "1.2.3"}}
-
-{{/* Regex Functions */}}
-RegexMatch: {{regexMatch "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$" "test@acme.com"}}
-RegexFindAll: {{regexFindAll "[2,4,6,8]" "123456789" -1}}
-RegexFind: {{regexFind "[a-zA-Z][1-9]" "abcd1234"}}
-RegexReplaceAll: {{regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W"}}
-RegexReplaceAllLiteral: {{regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}"}}
-RegexSplit: {{regexSplit "z+" "pizza" -1}}
-RegexQuoteMeta: {{regexQuoteMeta "1.2.3"}}
-
-{{/* URL Functions */}}
-UrlParse: {{index ( urlParse "proto://auth@host:80/path?query#fragment" ) "host" }}
-UrlJoin: {{urlJoin (dict "fragment" "fragment" "host" "host:80" "path" "/path" "query" "query" "scheme" "proto")}}
-
-
-{{/* Cannot be matched due to random */}}
-{{/* UUIDv4: {{uuidv4}} */}}
-{{/* RandBytes: {{randBytes 10}} */}}
-{{/* EncryptAES: {{encryptAES "secretkey" "plaintext"}} */}}
-{{/* DecryptAES: {{"30tEfhuJSVRhpG97XCuWgz2okj7L8vQ1s6V9zVUPeDQ=" | decryptAES "secretkey"}} */}}
-{{/* Bcrypt: {{bcrypt "Hello, World!"}} */}}
-{{/* Htpasswd: {{htpasswd "myUser" "myPassword"}} */}}
-{{/* genPrivateKey: {{genPrivateKey "rsa"}} | {{genPrivateKey "dsa"}} | {{genPrivateKey "ecdsa"}} | {{genPrivateKey "ed25519"}} */}}
-{{/* RandInt: {{randInt 5 10}} */}}
-{{/* RandAlphaNum: {{randAlphaNum 10}} */}}
-{{/* RandAlpha: {{randAlpha 10}} */}}
-{{/* RandAscii: {{randAscii 10}} */}}
-{{/* RandNumeric: {{randNumeric 10}} */}}
-{{/* Shuffle: {{shuffle "Hello, World!"}} */}}
-{{/* GetHostByName: {{getHostByName "localhost"}} */}}
+[CODE_000012]    {{ hello }}
+[CODE_000013]    {{ urlParse "https://example.com" | urlJoin }}
+[CODE_000014]    {{ urlParse "https://example.com/path" | urlJoin }}
+[CODE_000015]    {{ urlParse "https://user:pass@example.com/path?query=1" | urlJoin }}
+[CODE_000016]    {{sha1sum ""}}
+[CODE_000017]    {{sha1sum "a"}}
+[CODE_000018]    {{sha1sum "hello world"}}
+[CODE_000019]    {{sha256sum ""}}
+[CODE_000020]    {{sha256sum "a"}}
+[CODE_000021]    {{sha256sum "hello world"}}
+[CODE_000022]    {{adler32sum ""}}
+[CODE_000023]    {{adler32sum "a"}}
+[CODE_000024]    {{adler32sum "hello world"}}
+[CODE_000025]    {{$v := int .string }}{{kindOf $v}}-{{$v}}
+[CODE_000026]    {{$v := int .float }}{{kindOf $v}}-{{$v}}
+[CODE_000027]    {{$v := int .bool }}{{kindOf $v}}-{{$v}}
+[CODE_000028]    {{$v := int64 .string }}{{typeOf $v}}-{{$v}}
+[CODE_000029]    {{$v := int64 .float }}{{typeOf $v}}-{{$v}}
+[CODE_000030]    {{$v := int64 .int }}{{typeOf $v}}-{{$v}}
+[CODE_000031]    {{$v := int64 .bool }}{{typeOf $v}}-{{$v}}
+[CODE_000032]    {{$v := float64 .string }}{{typeOf $v}}-{{$v}}
+[CODE_000033]    {{$v := float64 .float }}{{typeOf $v}}-{{$v}}
+[CODE_000034]    {{$v := float64 .int }}{{typeOf $v}}-{{$v}}
+[CODE_000035]    {{$v := float64 .bool }}{{typeOf $v}}-{{$v}}
+[CODE_000036]    {{$v := toDecimal .string }}{{typeOf $v}}-{{$v}}
+[CODE_000037]    {{$v := toDecimal .float }}{{typeOf $v}}-{{$v}}
+[CODE_000038]    {{$v := toDecimal .int }}{{typeOf $v}}-{{$v}}
+[CODE_000039]    {{$v := toDecimal .bool }}{{typeOf $v}}-{{$v}}
+[CODE_000040]    {{$v := toString .string }}{{typeOf $v}}-{{$v}}
+[CODE_000041]    {{$v := toString .int }}{{typeOf $v}}-{{$v}}
+[CODE_000042]    {{$v := toString .float }}{{typeOf $v}}-{{$v}}
+[CODE_000043]    {{$v := toString .bool }}{{typeOf $v}}-{{$v}}
+[CODE_000044]    {{$v := toString .objectrray }}{{typeOf $v}}-{{$v}}
+[CODE_000045]    {{$v := toString .time }}{{typeOf $v}}-{{$v}}
+[CODE_000046]    {{$v := toString .duration }}{{typeOf $v}}-{{$v}}
+[CODE_000047]    {{$v := toString .object }}{{typeOf $v}}-{{$v}}
+[CODE_000048]    {{$v := toDate "2006-01-02" (.time | toString) }}{{typeOf $v}}-{{$v}}
+[CODE_000049]    {{ "" | b64enc }}
+[CODE_000050]    {{ "Hello World" | b64enc }}
+[CODE_000051]    {{ "SGVsbG8gV29ybGQ=" | b64dec }}
+[CODE_000052]    {{ "" | b32enc }}
+[CODE_000053]    {{ "Hello World" | b32enc }}
+[CODE_000054]    {{ "JBSWY3DPEBLW64TMMQ======" | b32dec }}
+[CODE_000055]    {{ "" | fromJson }}
+[CODE_000056]    {{ .json | fromJson }}
+[CODE_000057]    {{ (.json | fromJson).foo }}
+[CODE_000058]    {{ "" | toJson }}
+[CODE_000059]    {{ .object | toJson }}
+[CODE_000060]    {{ "" | toPrettyJson }}
+[CODE_000061]    {{ .object | toPrettyJson }}
+[CODE_000062]    {{ "" | toRawJson }}
+[CODE_000063]    {{ .object | toRawJson }}
+[CODE_000064]    {{ .json | mustFromJson }}
+[CODE_000065]    {{ .object | mustToJson }}
+[CODE_000066]    {{ .object | mustToPrettyJson }}
+[CODE_000067]    {{ .object | mustToRawJson }}
+[CODE_000068]    {{ env "" }}
+[CODE_000069]    {{ env "NON_EXISTENT_ENV_VAR" }}
+[CODE_000070]    {{ env "__SPROUT_TEST_ENV_KEY" }}
+[CODE_000071]    {{ "__SPROUT_TEST_ENV_KEY" | env }}
+[CODE_000072]    {{ expandenv "" }}
+[CODE_000073]    {{ expandenv "Hey" }}
+[CODE_000074]    {{ expandenv "$NON_EXISTENT_ENV_VAR" }}
+[CODE_000075]    {{ expandenv "Hey $__SPROUT_TEST_ENV_KEY" }}
+[CODE_000076]    {{ "Hey $__SPROUT_TEST_ENV_KEY" | expandenv }}
+[CODE_000077]    {{ base "" }}
+[CODE_000078]    {{ base "/" }}
+[CODE_000079]    {{ base "/path/to/file" }}
+[CODE_000080]    {{ base "/path/to/file.txt" }}
+[CODE_000081]    {{ "/path/to/file.txt" | base }}
+[CODE_000082]    {{ dir "" }}
+[CODE_000083]    {{ dir "/" }}
+[CODE_000084]    {{ dir "/path/to/file" }}
+[CODE_000085]    {{ dir "/path/to/file.txt" }}
+[CODE_000086]    {{ "/path/to/file.txt" | dir }}
+[CODE_000087]    {{ ext "" }}
+[CODE_000088]    {{ ext "/" }}
+[CODE_000089]    {{ ext "/path/to/file" }}
+[CODE_000090]    {{ ext "/path/to/file.txt" }}
+[CODE_000091]    {{ "/path/to/file.txt" | ext }}
+[CODE_000092]    {{ clean "" }}
+[CODE_000093]    {{ clean "/" }}
+[CODE_000094]    {{ clean "/path/to/file" }}
+[CODE_000095]    {{ clean "/path/to/file.txt" }}
+[CODE_000096]    {{ "/path/to/file.txt" | clean }}
+[CODE_000097]    {{ clean "/path//to/file" }}
+[CODE_000098]    {{ clean "/path/./to/file" }}
+[CODE_000099]    {{ clean "/path/../to/file" }}
+[CODE_000100]    {{ isAbs "" }}
+[CODE_000101]    {{ isAbs "/" }}
+[CODE_000102]    {{ isAbs "path/to/file" }}
+[CODE_000103]    {{ isAbs "/path/to/file.txt" }}
+[CODE_000104]    {{ "file.txt" | isAbs }}
+[CODE_000105]    {{ floor 1.5 }}
+[CODE_000106]    {{ floor 1 }}
+[CODE_000107]    {{ floor -1.5 }}
+[CODE_000108]    {{ floor -1 }}
+[CODE_000109]    {{ floor 0 }}
+[CODE_000110]    {{ floor 123 }}
+[CODE_000111]    {{ floor "123" }}
+[CODE_000112]    {{ floor 123.9999 }}
+[CODE_000113]    {{ floor 123.0001 }}
+[CODE_000114]    {{ ceil 1.5 }}
+[CODE_000115]    {{ ceil 1 }}
+[CODE_000116]    {{ ceil -1.5 }}
+[CODE_000117]    {{ ceil -1 }}
+[CODE_000118]    {{ ceil 0 }}
+[CODE_000119]    {{ ceil 123 }}
+[CODE_000120]    {{ ceil "123" }}
+[CODE_000121]    {{ ceil 123.9999 }}
+[CODE_000122]    {{ ceil 123.0001 }}
+[CODE_000123]    {{ round 3.746 2 }}
+[CODE_000124]    {{ round 3.746 2 0.5 }}
+[CODE_000125]    {{ round 123.5555 3 }}
+[CODE_000126]    {{ round "123.5555" 3 }}
+[CODE_000127]    {{ round 123.500001 0 }}
+[CODE_000128]    {{ round 123.49999999 0 }}
+[CODE_000129]    {{ round 123.2329999 2 .3 }}
+[CODE_000130]    {{ round 123.233 2 .3 }}
+[CODE_000131]    {{ add }}
+[CODE_000132]    {{ add 1 }}
+[CODE_000133]    {{ add 1 2 3 4 5 6 7 8 9 10 }}
+[CODE_000134]    {{ 10.1 | addf 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9 }}
+[CODE_000135]    {{ addf }}
+[CODE_000136]    {{ addf 1 }}
+[CODE_000137]    {{ addf 1 2 3 4 5 6 7 8 9 10 }}
+[CODE_000138]    {{ 10.1 | addf 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9 }}
+[CODE_000139]    {{ add1 -1 }}
+[CODE_000140]    {{ add1f -1.0}}
+[CODE_000141]    {{ add1 1 }}
+[CODE_000142]    {{ add1f 1.1 }}
+[CODE_000143]    {{ add1f -1 }}
+[CODE_000144]    {{ add1f -1.0}}
+[CODE_000145]    {{ add1f 1 }}
+[CODE_000146]    {{ add1f 1.1 }}
+[CODE_000147]    {{ sub 1 1 }}
+[CODE_000148]    {{ sub 1 2 }}
+[CODE_000149]    {{ subf 1.1 1.1 }}
+[CODE_000150]    {{ subf 1.1 2.2 }}
+[CODE_000151]    {{ 3 | sub 14 }}
+[CODE_000152]    {{ subf 1.1 1.1 }}
+[CODE_000153]    {{ subf 1.1 2.2 }}
+[CODE_000154]    {{ round (3 | subf 4.5 1) 1 }}
+[CODE_000155]    {{ mul 1 1 }}
+[CODE_000156]    {{ mul 1 2 }}
+[CODE_000157]    {{ mul 1.1 1.1 }}
+[CODE_000158]    {{ mul 1.1 2.2 }}
+[CODE_000159]    {{ 3 | mul 14 }}
+[CODE_000160]    {{ round (mulf 1.1 1.1) 2 }}
+[CODE_000161]    {{ round (mulf 1.1 2.2) 2 }}
+[CODE_000162]    {{ round (3.3 | mulf 14.4) 2 }}
+[CODE_000163]    {{ div 1 1 }}
+[CODE_000164]    {{ div 1 2 }}
+[CODE_000165]    {{ div 1.1 1.1 }}
+[CODE_000166]    {{ div 1.1 2.2 }}
+[CODE_000167]    {{ 4 | div 5 }}
+[CODE_000168]    {{ round (divf 1.1 1.1) 2 }}
+[CODE_000169]    {{ round (divf 1.1 2.2) 2 }}
+[CODE_000170]    {{ 2 | divf 5 4 }}
+[CODE_000171]    {{ mod 10 4 }}
+[CODE_000172]    {{ mod 10 3 }}
+[CODE_000173]    {{ mod 10 2 }}
+[CODE_000174]    {{ mod 10 1 }}
+[CODE_000175]    {{ min 1 }}
+[CODE_000176]    {{ min 1 "1" }}
+[CODE_000177]    {{ min -1 0 1 }}
+[CODE_000178]    {{ min 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 0 }}
+[CODE_000179]    {{ minf 1 }}
+[CODE_000180]    {{ minf 1 "1.1" }}
+[CODE_000181]    {{ minf -1.4 .0 2.1 }}
+[CODE_000182]    {{ minf .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 .1 .2 .3 .4 .5 .6 .7 .8 .9 .10}}
+[CODE_000183]    {{ max 1 }}
+[CODE_000184]    {{ max 1 "1" }}
+[CODE_000185]    {{ max -1 0 1 }}
+[CODE_000186]    {{ max 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 0 }}
+[CODE_000187]    {{ maxf 1 }}
+[CODE_000188]    {{ maxf 1.0 "1.1" }}
+[CODE_000189]    {{ maxf -1.5 0 1.4 }}
+[CODE_000190]    {{ maxf .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 .1 .2 .3 .4 .5 .6 .7 .8 .9 .10 }}
+[CODE_000191]    {{typeIs "int" 42}}
+[CODE_000192]    {{42 | typeIs "string"}}
+[CODE_000193]    {{$var := 42}}{{typeIs "string" $var}}
+[CODE_000194]    {{.object | typeIs "*reflect_test.testStruct"}}
+[CODE_000195]    {{typeIsLike "int" 42}}
+[CODE_000196]    {{42 | typeIsLike "string"}}
+[CODE_000197]    {{$var := 42}}{{typeIsLike "string" $var}}
+[CODE_000198]    {{.object | typeIsLike "*reflect_test.testStruct"}}
+[CODE_000199]    {{.object | typeIsLike "reflect_test.testStruct"}}
+[CODE_000200]    {{typeOf 42}}
+[CODE_000201]    {{typeOf "42"}}
+[CODE_000202]    {{$var := 42}}{{typeOf $var}}
+[CODE_000203]    {{typeOf .object}}
+[CODE_000204]    {{kindIs "int" 42}}
+[CODE_000205]    {{42 | kindIs "string"}}
+[CODE_000206]    {{$var := 42}}{{kindIs "string" $var}}
+[CODE_000207]    {{.object | kindIs "ptr"}}
+[CODE_000208]    {{kindOf 42}}
+[CODE_000209]    {{kindOf "42"}}
+[CODE_000210]    {{kindOf .object}}
+[CODE_000211]    {{$var := 42}}{{kindOf $var}}
+[CODE_000212]    {{kindOf .object}}
+[CODE_000213]    {{kindOf .object}}
+[CODE_000214]    {{deepEqual 42 42}}
+[CODE_000215]    {{deepEqual "42" "42"}}
+[CODE_000216]    {{deepEqual .object .object}}
+[CODE_000217]    {{$a := 42}}{{$b := 42}}{{deepEqual $a $b}}
+[CODE_000218]    {{deepEqual 42 32}}
+[CODE_000219]    {{deepEqual 42 "42"}}
+[CODE_000220]    {{$a := 42}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000221]    {{$a := "42"}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000222]    {{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000223]    {{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000224]    {{$a := .object}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000225]    {{$a := 42}}{{$b := deepCopy $a}}{{$b}}
+[CODE_000226]    {{$a := 42}}{{$b := deepCopy "42"}}{{$b}}
+[CODE_000227]    {{$a := 42}}{{$b := deepCopy 42.0}}{{$b}}
+[CODE_000228]    {{$b := deepCopy .object}}
+[CODE_000229]    {{- $d := dict "a" 1 "b" 2 | deepCopy }}{{ values $d | sortAlpha | join "," }}
+[CODE_000230]    {{- $d := dict "a" 1 "b" 2 | deepCopy }}{{ keys $d | sortAlpha | join "," }}
+[CODE_000231]    {{- $one := dict "foo" (dict "bar" "baz") "qux" true -}}{{ deepCopy $one }}
+[CODE_000232]    {{ regexFind "a(b+)" "aaabbb" }}
+[CODE_000233]    {{ regexFindAll "a(b+)" "aaabbb" -1 }}
+[CODE_000234]    {{ regexFindAll "a{2}" "aaaabbb" -1 }}
+[CODE_000235]    {{ regexFindAll "a{2}" "none" -1 }}
+[CODE_000236]    {{ regexMatch "^[a-zA-Z]+$" "Hello" }}
+[CODE_000237]    {{ regexMatch "^[a-zA-Z]+$" "Hello123" }}
+[CODE_000238]    {{ regexMatch "^[a-zA-Z]+$" "123" }}
+[CODE_000239]    {{ regexSplit "a" "banana" -1 }}
+[CODE_000240]    {{ regexSplit "a" "banana" 0 }}
+[CODE_000241]    {{ regexSplit "a" "banana" 1 }}
+[CODE_000242]    {{ regexSplit "a" "banana" 2 }}
+[CODE_000243]    {{ regexSplit "a+" "banana" 1 }}
+[CODE_000244]    {{ regexReplaceAll "a(x*)b" "-ab-axxb-" "T" }}
+[CODE_000245]    {{ regexReplaceAll "a(x*)b" "-ab-axxb-" "$1" }}
+[CODE_000246]    {{ regexReplaceAll "a(x*)b" "-ab-axxb-" "$1W" }}
+[CODE_000247]    {{ regexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W" }}
+[CODE_000248]    {{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "T" }}
+[CODE_000249]    {{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1" }}
+[CODE_000250]    {{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1W" }}
+[CODE_000251]    {{ regexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}W" }}
+[CODE_000252]    {{ regexQuoteMeta "Escaping $100? That's a lot." }}
+[CODE_000253]    {{ regexQuoteMeta "1.2.3" }}
+[CODE_000254]    {{ regexQuoteMeta "golang" }}
+[CODE_000255]    {{ mustRegexFind "a(b+)" "aaabbb" }}
+[CODE_000256]    {{ mustRegexFindAll "a(b+)" "aaabbb" -1 }}
+[CODE_000257]    {{ mustRegexFindAll "a{2}" "aaaabbb" -1 }}
+[CODE_000258]    {{ mustRegexFindAll "a{2}" "none" -1 }}
+[CODE_000259]    {{ mustRegexMatch "^[a-zA-Z]+$" "Hello" }}
+[CODE_000260]    {{ mustRegexMatch "^[a-zA-Z]+$" "Hello123" }}
+[CODE_000261]    {{ mustRegexMatch "^[a-zA-Z]+$" "123" }}
+[CODE_000262]    {{ mustRegexSplit "a" "banana" -1 }}
+[CODE_000263]    {{ mustRegexSplit "a" "banana" 0 }}
+[CODE_000264]    {{ mustRegexSplit "a" "banana" 1 }}
+[CODE_000265]    {{ mustRegexSplit "a" "banana" 2 }}
+[CODE_000266]    {{ mustRegexSplit "a+" "banana" 1 }}
+[CODE_000267]    {{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "T" }}
+[CODE_000268]    {{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "$1" }}
+[CODE_000269]    {{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "$1W" }}
+[CODE_000270]    {{ mustRegexReplaceAll "a(x*)b" "-ab-axxb-" "${1}W" }}
+[CODE_000271]    {{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "T" }}
+[CODE_000272]    {{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1" }}
+[CODE_000273]    {{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "$1W" }}
+[CODE_000274]    {{ mustRegexReplaceAllLiteral "a(x*)b" "-ab-axxb-" "${1}W" }}
+[CODE_000275]    {{ semver "1.0.0" }}
+[CODE_000276]    {{ semver "1.0.0-alpha" }}
+[CODE_000277]    {{ semver "1.0.0-alpha.1" }}
+[CODE_000278]    {{ semver "1.0.0-alpha.1+build" }}
+[CODE_000279]    {{ semverCompare "1.0.0" "1.0.0" }}
+[CODE_000280]    {{ semverCompare "1.0.0" "1.0.1" }}
+[CODE_000281]    {{ semverCompare "1.0.1" "1.0.0" }}
+[CODE_000282]    {{ semverCompare "~1.0.0" "1.0.0" }}
+[CODE_000283]    {{ semverCompare ">=1.0.0" "1.0.0-alpha" }}
+[CODE_000284]    {{ semverCompare ">1.0.0-alpha" "1.0.0-alpha.1" }}
+[CODE_000285]    {{ semverCompare "1.0.0-alpha.1" "1.0.0-alpha" }}
+[CODE_000286]    {{ semverCompare "1.0.0-alpha.1" "1.0.0-alpha.1" }}
+[CODE_000287]    {{ list }}
+[CODE_000288]    {{ .string | list "ab" true 4 5 }}
+[CODE_000289]    {{ append .array "a" }}
+[CODE_000290]    {{ prepend .array "a" }}
+[CODE_000291]    {{ concat .array (list 1 2 3) }}
+[CODE_000292]    {{ list 4 5 | concat (list 1 2 3) }}
+[CODE_000293]    {{ chunk 2 .array }}
+[CODE_000294]    {{ uniq .array }}
+[CODE_000295]    {{ compact .array }}
+[CODE_000296]    {{ list 1 0 "" "hello" | compact }}
+[CODE_000297]    {{ list "" "" | compact }}
+[CODE_000298]    {{ list | compact }}
+[CODE_000299]    {{ slice .array }}
+[CODE_000300]    {{ slice .array 1 }}
+[CODE_000301]    {{ slice .array 1 3 }}
+[CODE_000302]    {{ slice .array 0 1 }}
+[CODE_000303]    {{ .array | has "foo" }}
+[CODE_000304]    {{ .array | has "a" }}
+[CODE_000305]    {{ .array | has 1 }}
+[CODE_000306]    {{ .array | has .nil }}
+[CODE_000307]    {{ .array | has "nope" }}
+[CODE_000308]    {{ without .array "a" }}
+[CODE_000309]    {{ rest .array }}
+[CODE_000310]    {{ initial .array }}
+[CODE_000311]    {{ first .array }}
+[CODE_000312]    {{ last .array }}
+[CODE_000313]    {{ reverse .array }}
+[CODE_000314]    {{ sortAlpha .array }}
+[CODE_000315]    {{ .arrayCommas | splitList "," }}
+[CODE_000316]    {{ toStrings .arrayCommas }}
+[CODE_000317]    {{range $i, $e := until 5}}({{$i}}{{$e}}){{end}}
+[CODE_000318]    {{range $i, $e := until -5}}({{$i}}{{$e}}){{end}}
+[CODE_000319]    {{range $i, $e := untilStep 0 5 1}}({{$i}}{{$e}}){{end}}
+[CODE_000320]    {{range $i, $e := untilStep 3 6 1}}({{$i}}{{$e}}){{end}}
+[CODE_000321]    {{range $i, $e := untilStep 0 -10 -2}}({{$i}}{{$e}}){{end}}
+[CODE_000322]    {{range $i, $e := untilStep 3 0 1}}({{$i}}{{$e}}){{end}}
+[CODE_000323]    {{range $i, $e := untilStep 3 99 0}}({{$i}}{{$e}}){{end}}
+[CODE_000324]    {{range $i, $e := untilStep 3 99 -1}}({{$i}}{{$e}}){{end}}
+[CODE_000325]    {{range $i, $e := untilStep 3 0 0}}({{$i}}{{$e}}){{end}}
+[CODE_000326]    {{ mustAppend .array "a" }}
+[CODE_000327]    {{ mustPrepend .array "a" }}
+[CODE_000328]    {{ mustChunk 2 .array }}
+[CODE_000329]    {{ mustUniq .array }}
+[CODE_000330]    {{ mustCompact .array }}
+[CODE_000331]    {{ mustSlice .array }}
+[CODE_000332]    {{ mustSlice .array 1 }}
+[CODE_000333]    {{ mustSlice .array 1 3 }}
+[CODE_000334]    {{ mustSlice .array 0 1 }}
+[CODE_000335]    {{ .array | mustHas "foo" }}
+[CODE_000336]    {{ .array | mustHas "a" }}
+[CODE_000337]    {{ .array | mustHas 1 }}
+[CODE_000338]    {{ .array | mustHas .Nil }}
+[CODE_000339]    {{ .array | mustHas "nope" }}
+[CODE_000340]    {{ .array | mustHas 1 }}
+[CODE_000341]    {{ mustWithout .array "a" }}
+[CODE_000342]    {{ mustRest .array }}
+[CODE_000343]    {{ mustInitial .array }}
+[CODE_000344]    {{ mustFirst .array }}
+[CODE_000345]    {{ mustLast .array }}
+[CODE_000346]    {{ mustReverse .array }}
+[CODE_000347]    {{hello}}
+[CODE_000348]    {{default "default" ""}}
+[CODE_000349]    {{default "default" "given"}}
+[CODE_000350]    {{default "default" 42}}
+[CODE_000351]    {{default "default" 2.42}}
+[CODE_000352]    {{default "default" true}}
+[CODE_000353]    {{default "default" false}}
+[CODE_000354]    {{default "default" nil}}
+[CODE_000355]    {{default "default" .nil}}
+[CODE_000356]    {{"first" | default "default" "second"}}
+[CODE_000357]    {{if empty ""}}1{{else}}0{{end}}
+[CODE_000358]    {{if empty "given"}}1{{else}}0{{end}}
+[CODE_000359]    {{if empty 42}}1{{else}}0{{end}}
+[CODE_000360]    {{if empty .int}}1{{else}}0{{end}}
+[CODE_000361]    {{if empty .string}}1{{else}}0{{end}}
+[CODE_000362]    {{if empty 2.42}}1{{else}}0{{end}}
+[CODE_000363]    {{if empty true}}1{{else}}0{{end}}
+[CODE_000364]    {{if empty false}}1{{else}}0{{end}}
+[CODE_000365]    {{if empty nil}}1{{else}}0{{end}}
+[CODE_000366]    {{if empty .nil}}1{{else}}0{{end}}
+[CODE_000367]    {{if all ""}}1{{else}}0{{end}}
+[CODE_000368]    {{if all "given"}}1{{else}}0{{end}}
+[CODE_000369]    {{if all 42 0 1}}1{{else}}0{{end}}
+[CODE_000370]    {{ $two := 2 }}{{if all "" 0 nil $two }}1{{else}}0{{end}}
+[CODE_000371]    {{ $two := 2 }}{{if all "" $two 0 0 0 }}1{{else}}0{{end}}
+[CODE_000372]    {{ $two := 2 }}{{if all "" $two 3 4 5 }}1{{else}}0{{end}}
+[CODE_000373]    {{if all }}1{{else}}0{{end}}
+[CODE_000374]    {{if any ""}}1{{else}}0{{end}}
+[CODE_000375]    {{if any "given"}}1{{else}}0{{end}}
+[CODE_000376]    {{if any 42 0 1}}1{{else}}0{{end}}
+[CODE_000377]    {{ $two := 2 }}{{if any "" 0 nil $two }}1{{else}}0{{end}}
+[CODE_000378]    {{ $two := 2 }}{{if any "" $two 3 4 5 }}1{{else}}0{{end}}
+[CODE_000379]    {{ $zero := 0 }}{{if any "" $zero 0 0 0 }}1{{else}}0{{end}}
+[CODE_000380]    {{if any }}1{{else}}0{{end}}
+[CODE_000381]    {{coalesce ""}}
+[CODE_000382]    {{coalesce "given"}}
+[CODE_000383]    {{ coalesce "" 0 nil 42 }}
+[CODE_000384]    {{ $two := 2 }}{{ coalesce "" 0 nil $two }}
+[CODE_000385]    {{ $two := 2 }}{{ coalesce "" $two 0 0 0 }}
+[CODE_000386]    {{ $two := 2 }}{{ coalesce "" $two 3 4 5 }}
+[CODE_000387]    {{ coalesce }}
+[CODE_000388]    {{true | ternary "foo" "bar"}}
+[CODE_000389]    {{ternary "foo" "bar" true}}
+[CODE_000390]    {{false | ternary "foo" "bar"}}
+[CODE_000391]    {{ternary "foo" "bar" false}}
+[CODE_000392]    {{cat ""}}
+[CODE_000393]    {{cat "given"}}
+[CODE_000394]    {{cat 42}}
+[CODE_000395]    {{cat 2.42}}
+[CODE_000396]    {{cat true}}
+[CODE_000397]    {{cat false}}
+[CODE_000398]    {{cat nil}}
+[CODE_000399]    {{cat .nil}}
+[CODE_000400]    {{cat "first" "second"}}
+[CODE_000401]    {{"first" | cat "second"}}
+[CODE_000402]    {{$b := "b"}}{{"c" | cat "a" $b}}
+[CODE_000403]    {{.string | cat "a" "b"}}
+[CODE_000404]    {{ "" | nospace }}
+[CODE_000405]    {{ " " | nospace }}
+[CODE_000406]    {{ " foo" | nospace }}
+[CODE_000407]    {{ "foo " | nospace }}
+[CODE_000408]    {{ " foo " | nospace }}
+[CODE_000409]    {{ " foo bar " | nospace }}
+[CODE_000410]    {{ "" | trim }}
+[CODE_000411]    {{ " " | trim }}
+[CODE_000412]    {{ " foo" | trim }}
+[CODE_000413]    {{ "foo " | trim }}
+[CODE_000414]    {{ " foo " | trim }}
+[CODE_000415]    {{ " foo bar " | trim }}
+[CODE_000416]    {{ "" | trimAll "-" }}
+[CODE_000417]    {{ "---------" | trimAll "-" }}
+[CODE_000418]    {{ "foo" | trimAll "-" }}
+[CODE_000419]    {{ "-f--o-o-" | trimAll "-" }}
+[CODE_000420]    {{ "-f--o-o-" | trimAll "-o" }}
+[CODE_000421]    {{ "" | trimPrefix "-" }}
+[CODE_000422]    {{ "--" | trimPrefix "-" }}
+[CODE_000423]    {{ "foo" | trimPrefix "-" }}
+[CODE_000424]    {{ "-foo-" | trimPrefix "-" }}
+[CODE_000425]    {{ "-foo-" | trimPrefix "-f" }}
+[CODE_000426]    {{ "" | trimSuffix "-" }}
+[CODE_000427]    {{ "--" | trimSuffix "-" }}
+[CODE_000428]    {{ "foo" | trimSuffix "-" }}
+[CODE_000429]    {{ "-foo-" | trimSuffix "-" }}
+[CODE_000430]    {{ "-foo-" | trimSuffix "o-" }}
+[CODE_000431]    {{ "" | contains "-" }}
+[CODE_000432]    {{ "foo" | contains "o" }}
+[CODE_000433]    {{ "foo" | contains "x" }}
+[CODE_000434]    {{ "" | hasPrefix "-" }}
+[CODE_000435]    {{ "foo" | hasPrefix "f" }}
+[CODE_000436]    {{ "foo" | hasPrefix "o" }}
+[CODE_000437]    {{ "" | hasSuffix "-" }}
+[CODE_000438]    {{ "foo" | hasSuffix "o" }}
+[CODE_000439]    {{ "foo" | hasSuffix "f" }}
+[CODE_000440]    {{ "" | lower }}
+[CODE_000441]    {{ "foo" | lower }}
+[CODE_000442]    {{ "FOO" | lower }}
+[CODE_000443]    {{ "" | upper }}
+[CODE_000444]    {{ "foo" | upper }}
+[CODE_000445]    {{ "FOO" | upper }}
+[CODE_000446]    {{ "" | replace "-" "x" }}
+[CODE_000447]    {{ "foo" | replace "o" "x" }}
+[CODE_000448]    {{ "foo" | replace "x" "y" }}
+[CODE_000449]    {{ "foo" | replace "o" "x" | replace "f" "y" }}
+[CODE_000450]    {{ "" | repeat 3 }}
+[CODE_000451]    {{ "foo" | repeat 3 }}
+[CODE_000452]    {{ "foo" | repeat 0 }}
+[CODE_000453]    {{ .nil | join "-" }}
+[CODE_000454]    {{ .test | join "-" }}
+[CODE_000455]    {{ .test | join "-" }}
+[CODE_000456]    {{ .test | join "-" }}
+[CODE_000457]    {{ .test | join "-" }}
+[CODE_000458]    {{ "" | trunc 3 }}
+[CODE_000459]    {{ "foooooo" | trunc 3 }}
+[CODE_000460]    {{ "foobar" | trunc -3 }}
+[CODE_000461]    {{ "foobar" | trunc -999 }}
+[CODE_000462]    {{ "foobar" | trunc 0 }}
+[CODE_000463]    {{ "" | abbrev 3 }}
+[CODE_000464]    {{ "foo" | abbrev 5 }}
+[CODE_000465]    {{ "foooooo" | abbrev 6 }}
+[CODE_000466]    {{ "foobar" | abbrev 0 }}
+[CODE_000467]    {{ "" | abbrevboth 3 5 }}
+[CODE_000468]    {{ "foo" | abbrevboth 5 4 }}
+[CODE_000469]    `"foooboooooo" | abbrevboth 4 9` excluded due to fixed output in Sprig
+[CODE_000470]    {{ "foobar" | abbrevboth 0 0 }}
+[CODE_000471]    {{ "" | initials }}
+[CODE_000472]    {{ "f" | initials }}
+[CODE_000473]    {{ "foo" | initials }}
+[CODE_000474]    {{ "foo bar" | initials }}
+[CODE_000475]    {{ "foo  bar" | initials }}
+[CODE_000476]    {{ " Foo bar" | initials }}
+[CODE_000477]    {{ 0 | plural "single" "many" }}
+[CODE_000478]    {{ 1 | plural "single" "many" }}
+[CODE_000479]    {{ 2 | plural "single" "many" }}
+[CODE_000480]    {{ -1 | plural "single" "many" }}
+[CODE_000481]    {{ "" | wrap 10 }}
+[CODE_000482]    {{ wrap -1 "With a negative wrap." }}
+[CODE_000483]    {{ "This is a long string that needs to be wrapped." | wrap 10 }}
+[CODE_000484]    {{ "" | wrapWith 10 "\t" }}
+[CODE_000485]    {{ "This is a long string that needs to be wrapped." | wrapWith 10 "\t" }}
+[CODE_000486]    {{ "This is a long string that needs to be wrapped with a looooooooooooooooooooooooooooooooooooong word." | wrapWith 10 "\t" }}
+[CODE_000487]    {{ "" | quote }}
+[CODE_000488]    {{ quote .nil }}
+[CODE_000489]    {{ "foo" | quote }}
+[CODE_000490]    {{ "foo bar" | quote }}
+[CODE_000491]    {{ "foo \"bar\"" | quote }}
+[CODE_000492]    {{ "foo\nbar" | quote }}
+[CODE_000493]    {{ "foo\\bar" | quote }}
+[CODE_000494]    {{ "foo\\\"bar" | quote }}
+[CODE_000495]    {{ quote "foo" "👍" }}
+[CODE_000496]    {{ "" | squote }}
+[CODE_000497]    {{ squote .nil }}
+[CODE_000498]    {{ "foo" | squote }}
+[CODE_000499]    {{ "foo bar" | squote }}
+[CODE_000500]    {{ "foo 'bar'" | squote }}
+[CODE_000501]    {{ "foo\nbar" | squote }}
+[CODE_000502]    {{ "foo\\bar" | squote }}
+[CODE_000503]    {{ "foo\\'bar" | squote }}
+[CODE_000504]    {{ squote "foo" "👍" }}
+[CODE_000505]    {{ "" | camelcase }}
+[CODE_000506]    {{ "foo bar" | camelcase }}
+[CODE_000507]    `"FoO  bar" | camelcase` excluded due to fixed output in Sprig
+[CODE_000508]    `"foo  bar" | camelcase` excluded due to fixed output in Sprig
+[CODE_000509]    {{ "foo_bar" | camelcase }}
+[CODE_000510]    {{ "foo-bar" | camelcase }}
+[CODE_000511]    {{ "foo-bar_baz" | camelcase }}
+[CODE_000512]    `camelcase "___complex__case_"` excluded due to fixed output in Sprig
+[CODE_000513]    `camelcase "_camel_case"` excluded due to fixed output in Sprig
+[CODE_000514]    {{ camelcase "http_server" }}
+[CODE_000515]    {{ camelcase "no_https" }}
+[CODE_000516]    {{ camelcase "all" }}
+[CODE_000517]    {{ "" | kebabcase }}
+[CODE_000518]    {{ "foo bar" | kebabcase }}
+[CODE_000519]    `"foo  bar" | kebabcase` excluded due to fixed output in Sprig
+[CODE_000520]    {{ "foo_bar" | kebabcase }}
+[CODE_000521]    {{ "foo-bar" | kebabcase }}
+[CODE_000522]    {{ "foo-bar_baz" | kebabcase }}
+[CODE_000523]    {{ kebabcase "HTTPServer" }}
+[CODE_000524]    {{ kebabcase "FirstName" }}
+[CODE_000525]    {{ kebabcase "NoHTTPS" }}
+[CODE_000526]    {{ kebabcase "GO_PATH" }}
+[CODE_000527]    {{ kebabcase "GO PATH" }}
+[CODE_000528]    {{ kebabcase "GO-PATH" }}
+[CODE_000529]    {{ "" | snakecase }}
+[CODE_000530]    {{ "foo bar" | snakecase }}
+[CODE_000531]    `"foo  bar" | snakecase` excluded due to fixed output in Sprig
+[CODE_000532]    {{ "foo_bar" | snakecase }}
+[CODE_000533]    {{ "foo-bar" | snakecase }}
+[CODE_000534]    {{ "foo-bar_baz" | snakecase }}
+[CODE_000535]    {{ snakecase "http2xx" }}
+[CODE_000536]    {{ snakecase "HTTP20xOK" }}
+[CODE_000537]    `snakecase "Duration2m3s"` excluded due to fixed output in Sprig
+[CODE_000538]    `snakecase "Bld4Floor3rd"` excluded due to fixed output in Sprig
+[CODE_000539]    {{ snakecase "FirstName" }}
+[CODE_000540]    {{ snakecase "HTTPServer" }}
+[CODE_000541]    {{ snakecase "NoHTTPS" }}
+[CODE_000542]    {{ snakecase "GO_PATH" }}
+[CODE_000543]    {{ snakecase "GO PATH" }}
+[CODE_000544]    {{ snakecase "GO-PATH" }}
+[CODE_000545]    {{ "" | title }}
+[CODE_000546]    {{ "foo bar" | title }}
+[CODE_000547]    {{ "foo  bar" | title }}
+[CODE_000548]    {{ "foo_bar" | title }}
+[CODE_000549]    {{ "foo-bar" | title }}
+[CODE_000550]    {{ "foo-bar_baz" | title }}
+[CODE_000551]    {{ "" | untitle }}
+[CODE_000552]    {{ "Foo Bar" | untitle }}
+[CODE_000553]    {{ "Foo  Bar" | untitle }}
+[CODE_000554]    {{ "Foo_bar" | untitle }}
+[CODE_000555]    {{ "Foo-Bar" | untitle }}
+[CODE_000556]    {{ "Foo-Bar_baz" | untitle }}
+[CODE_000557]    {{ "" | swapcase }}
+[CODE_000558]    {{ "Foo Bar" | swapcase }}
+[CODE_000559]    {{ "Foo  Bar" | swapcase }}
+[CODE_000560]    {{ "Foo_bar" | swapcase }}
+[CODE_000561]    {{ "Foo-Bar" | swapcase }}
+[CODE_000562]    {{ "Foo-Bar_baz" | swapcase }}
+[CODE_000563]    {{ $v := ("" | split "-") }}{{$v._0}}
+[CODE_000564]    {{ $v := ("foo$bar$baz" | split "$") }}{{$v._0}} {{$v._1}} {{$v._2}}
+[CODE_000565]    {{ $v := ("foo$bar$" | split "$") }}{{$v._0}} {{$v._1}} {{$v._2}}
+[CODE_000566]    {{ $v := ("" | splitn "-" 3) }}{{$v._0}}
+[CODE_000567]    {{ $v := ("foo$bar$baz" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
+[CODE_000568]    {{ $v := ("foo$bar$" | splitn "$" 2) }}{{$v._0}} {{$v._1}}
+[CODE_000569]    {{ "" | substr 0 3 }}
+[CODE_000570]    {{ "foobar" | substr 0 3 }}
+[CODE_000571]    `"foobar" | substr 0 -3` excluded due to fixed output in Sprig
+[CODE_000572]    `"foobar" | substr -3 6` excluded due to fixed output in Sprig
+[CODE_000573]    {{ "" | indent 3 }}
+[CODE_000574]    {{ "foo\nbar" | indent 3 }}
+[CODE_000575]    {{ "foo\n bar" | indent 3 }}
+[CODE_000576]    {{ "foo\n\tbar" | indent 3 }}
+[CODE_000577]    {{ "" | nindent 3 }}
+[CODE_000578]    {{ "foo\nbar" | nindent 3 }}
+[CODE_000579]    {{ "foo\n bar" | nindent 3 }}
+[CODE_000580]    {{ "foo\n\tbar" | nindent 3 }}
+[CODE_000581]    {{ seq 0 1 3 }}
+[CODE_000582]    {{ seq 0 3 10 }}
+[CODE_000583]    {{ seq 3 3 2 }}
+[CODE_000584]    {{ seq 3 -3 2 }}
+[CODE_000585]    {{ seq }}
+[CODE_000586]    {{ seq 0 4 }}
+[CODE_000587]    {{ seq 5 }}
+[CODE_000588]    {{ seq -5 }}
+[CODE_000589]    {{ seq 0 }}
+[CODE_000590]    {{ seq 0 1 2 3 }}
+[CODE_000591]    {{ seq 0 -4 }}
+[CODE_000592]    {{ .data265 | date "02 Jan 06 15:04 -0700" }}
+[CODE_000593]    {{ .data266 | date "02 Jan 06 15:04 -0700" }}
+[CODE_000594]    {{ .data267 | date "02 Jan 06 15:04 -0700" }}
+[CODE_000595]    {{ .data268 | date "02 Jan 06 15:04 -0700" }}
+[CODE_000596]    {{ dateInZone "02 Jan 06 15:04 -0700" .data269 "UTC" }}
+[CODE_000597]    {{ dateInZone "02 Jan 06 15:04 -0700" .data270 "UTC" }}
+[CODE_000598]    {{ dateInZone "02 Jan 06 15:04 -0700" .data271 "UTC" }}
+[CODE_000599]    {{ dateInZone "02 Jan 06 15:04 -0700" .data272 "UTC" }}
+[CODE_000600]    {{ dateInZone "02 Jan 06 15:04 -0700" .data273 "UTC" }}
+[CODE_000601]    {{ dateInZone "02 Jan 06 15:04 -0700" .data274 "UTC" }}
+[CODE_000602]    {{ dateInZone "02 Jan 06 15:04 -0700" .data275 "invalid" }}
+[CODE_000603]    {{ .duration | duration }}
+[CODE_000604]    {{ .time | ago | substr 0 5 }}
+[CODE_000605]    {{ now | date "02 Jan 06 15:04 -0700" }}
+[CODE_000606]    {{ .time | unixEpoch }}
+[CODE_000607]    {{ .time | dateModify "1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000608]    {{ .time | dateModify "+1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000609]    {{ .time | dateModify "-1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000610]    {{ .time | dateModify "10m" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000611]    {{ .time | dateModify "-10s" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000612]    {{ .time | dateModify "zz" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000613]    {{ .duration | duration | durationRound }}
+[CODE_000614]    {{ .time | htmlDate }}
+[CODE_000615]    {{ htmlDateInZone .time "UTC" }}
+[CODE_000616]    {{ .time | mustDateModify "1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000617]    {{ .time | mustDateModify "+1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000618]    {{ .time | mustDateModify "-1h" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000619]    {{ .time | mustDateModify "10m" | date "02 Jan 06 15:04 -0700" }}
+[CODE_000620]    {{ .time | mustDateModify "-10s" | date "02 Jan 06 15:04 -0700" }}

--- a/docs/registries/crypto.md
+++ b/docs/registries/crypto.md
@@ -149,8 +149,8 @@ The function generates a new, self-signed x509 certificate using a 2048-bit RSA 
 
 <table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">GenerateSelfSignedCertificate(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 ) (Certificate, error)
 </code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
@@ -170,8 +170,8 @@ The function generates a new, self-signed x509 certificate using a provided priv
 
 <table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">GenerateSelfSignedCertificateWithPEMKey(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	privPEM string,
 ) (Certificate, error)
@@ -192,8 +192,8 @@ The function generates a new x509 certificate that is signed by a given Certific
 
 <table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">GenerateSignedCertificate(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	ca Certificate,
 ) (Certificate, error)
@@ -214,8 +214,8 @@ The function generates a new, signed x509 certificate using a given Certificate 
 
 <table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">GenerateSignedCertificateWithPEMKey(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	ca Certificate,
 	privPEM string,

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -174,9 +174,9 @@ func Empty(given any) bool {
 		return g.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return g.Float() == 0
-	case reflect.Struct:
-		return false
-	default:
+	case reflect.Interface, reflect.Ptr:
 		return g.IsNil()
+	default:
+		return false
 	}
 }

--- a/registry/conversion/functions.go
+++ b/registry/conversion/functions.go
@@ -156,7 +156,7 @@ func (cr *ConversionRegistry) ToString(v any) string {
 	case fmt.Stringer:
 		return v.String()
 	default:
-		return fmt.Sprintf("%v", v)
+		return fmt.Sprint(v)
 	}
 }
 

--- a/registry/crypto/functions.go
+++ b/registry/crypto/functions.go
@@ -116,7 +116,7 @@ func (ch *CryptoRegistry) DerivePassword(counter uint32, passwordType, password,
 //
 //	{{ generatePrivateKey "rsa" }} // Output: "-----BEGIN RSA PRIVATE KEY-----"
 func (ch *CryptoRegistry) GeneratePrivateKey(typ string) string {
-	var priv interface{}
+	var priv any
 	var err error
 	switch typ {
 	case "", "rsa":
@@ -261,8 +261,8 @@ func (ch *CryptoRegistry) GenerateCertificateAuthorityWithPEMKey(
 //	{{ generateSelfSignedCertificate "example.com" ["127.0.0.1"] ["localhost"] 365 }} // Output: {"Cert":"b64cert","Key":"b64key"}
 func (ch *CryptoRegistry) GenerateSelfSignedCertificate(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 ) (Certificate, error) {
 	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
@@ -290,8 +290,8 @@ func (ch *CryptoRegistry) GenerateSelfSignedCertificate(
 //	{{ generateSelfSignedCertificateWithPEMKey "example.com" ["127.0.0.1"] ["localhost"] 365 "privPEM" }} // Output: {"Cert":"b64cert","Key":"b64key"}
 func (ch *CryptoRegistry) GenerateSelfSignedCertificateWithPEMKey(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	privPEM string,
 ) (Certificate, error) {
@@ -320,8 +320,8 @@ func (ch *CryptoRegistry) GenerateSelfSignedCertificateWithPEMKey(
 //	{{ generateSignedCertificate "example.com" ["127.0.0.1"] ["localhost"] 365 ca }} // Output: {"Cert":"b64cert","Key":"b64key"}
 func (ch *CryptoRegistry) GenerateSignedCertificate(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	ca Certificate,
 ) (Certificate, error) {
@@ -351,8 +351,8 @@ func (ch *CryptoRegistry) GenerateSignedCertificate(
 //	{{ generateSignedCertificateWithPEMKey "example.com" ["127.0.0.1"] ["localhost"] 365 ca "privPEM" }} // Output: {"Cert":"b64cert","Key":"b64key"}
 func (ch *CryptoRegistry) GenerateSignedCertificateWithPEMKey(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	ca Certificate,
 	privPEM string,

--- a/registry/crypto/helpers.go
+++ b/registry/crypto/helpers.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-func (ch *CryptoRegistry) getNetIPs(ips []interface{}) ([]net.IP, error) {
+func (ch *CryptoRegistry) getNetIPs(ips []any) ([]net.IP, error) {
 	if ips == nil {
 		return []net.IP{}, nil
 	}
@@ -41,7 +41,7 @@ func (ch *CryptoRegistry) getNetIPs(ips []interface{}) ([]net.IP, error) {
 	return netIPs, nil
 }
 
-func (ch *CryptoRegistry) getAlternateDNSStrs(alternateDNS []interface{}) ([]string, error) {
+func (ch *CryptoRegistry) getAlternateDNSStrs(alternateDNS []any) ([]string, error) {
 	if alternateDNS == nil {
 		return []string{}, nil
 	}
@@ -63,8 +63,8 @@ func (ch *CryptoRegistry) getAlternateDNSStrs(alternateDNS []interface{}) ([]str
 
 func (ch *CryptoRegistry) getBaseCertTemplate(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 ) (*x509.Certificate, error) {
 	ipAddresses, err := ch.getNetIPs(ips)
@@ -98,7 +98,7 @@ func (ch *CryptoRegistry) getBaseCertTemplate(
 	}, nil
 }
 
-func (ch *CryptoRegistry) pemBlockForKey(priv interface{}) *pem.Block {
+func (ch *CryptoRegistry) pemBlockForKey(priv any) *pem.Block {
 	switch k := priv.(type) {
 	case *rsa.PrivateKey:
 		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
@@ -207,8 +207,8 @@ func (ch *CryptoRegistry) generateCertificateAuthorityWithKeyInternal(
 
 func (ch *CryptoRegistry) generateSelfSignedCertificateWithKeyInternal(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	priv crypto.PrivateKey,
 ) (Certificate, error) {
@@ -226,8 +226,8 @@ func (ch *CryptoRegistry) generateSelfSignedCertificateWithKeyInternal(
 
 func (ch *CryptoRegistry) generateSignedCertificateWithKeyInternal(
 	cn string,
-	ips []interface{},
-	alternateDNS []interface{},
+	ips []any,
+	alternateDNS []any,
 	daysValid int,
 	ca Certificate,
 	priv crypto.PrivateKey,

--- a/registry/maps/functions.go
+++ b/registry/maps/functions.go
@@ -166,7 +166,8 @@ func (mr *MapsRegistry) Values(dict map[string]any) []any {
 //	{{ $d2 := dict "key" "value2" }}
 //	{{ pluck "key"	$d1 $d2 }} // Output: ["value1", "value2"]
 func (mr *MapsRegistry) Pluck(key string, dicts ...map[string]any) []any {
-	result := []any{}
+	result := make([]any, 0, len(dicts))
+
 	for _, dict := range dicts {
 		if val, ok := dict[key]; ok {
 			result = append(result, val)
@@ -191,7 +192,9 @@ func (mr *MapsRegistry) Pluck(key string, dicts ...map[string]any) []any {
 //	{{ $d := dict "key1" "value1" "key2" "value2" "key3" "value3" }}
 //	{{ pick $d "key1" "key3" }} // Output: {"key1": "value1", "key3": "value3"}
 func (mr *MapsRegistry) Pick(dict map[string]any, keys ...string) map[string]any {
-	result := map[string]any{}
+	// Pre-allocate result map with the size of keys to avoid multiple allocations
+	result := make(map[string]any, len(keys))
+
 	for _, k := range keys {
 		if v, ok := dict[k]; ok {
 			result[k] = v
@@ -216,11 +219,14 @@ func (mr *MapsRegistry) Pick(dict map[string]any, keys ...string) map[string]any
 //	{{ $d := dict "key1" "value1" "key2" "value2" "key3" "value3" }}
 //	{{ omit $d "key1" "key3" }} // Output: {"key2": "value2"}
 func (mr *MapsRegistry) Omit(dict map[string]any, keys ...string) map[string]any {
-	result := map[string]any{}
+	// Pre-allocate result map with the size of the original dictionary to avoid
+	// multiple allocations
+	result := make(map[string]any, len(dict))
 
-	omit := make(map[string]bool, len(keys))
+	// Use a map for keys to omit for O(1) lookups
+	omit := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
-		omit[key] = true
+		omit[key] = struct{}{}
 	}
 
 	for key, value := range dict {

--- a/registry/numeric/helpers.go
+++ b/registry/numeric/helpers.go
@@ -35,6 +35,14 @@ func operateNumeric(values []any, op numericOperation, initial any) any {
 		result = op(result, cast.ToFloat64(value))
 	}
 
+	// Direct type assertion for common types to avoid reflection overhead
 	initialType := reflect.TypeOf(values[0])
-	return reflect.ValueOf(result).Convert(initialType).Interface()
+	switch initialType.Kind() {
+	case reflect.Int:
+		return int(result)
+	case reflect.Float64:
+		return result
+	default:
+		return reflect.ValueOf(result).Convert(initialType).Interface()
+	}
 }

--- a/registry/numeric/helpers_test.go
+++ b/registry/numeric/helpers_test.go
@@ -1,0 +1,27 @@
+package numeric
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOperateNumeric(t *testing.T) {
+	var tests = []struct {
+		values   []any
+		op       numericOperation
+		initial  any
+		expected any
+	}{
+		{[]any{1, 2}, func(a, b float64) float64 { return a + b }, 0, 3},
+		{[]any{1.5, 2.5}, func(a, b float64) float64 { return a - b }, 0, -1.0},
+		{[]any{1.5, 2.5}, func(a, b float64) float64 { return a * b }, 1, 3.75},
+		{[]any{1.5, 2.5}, func(a, b float64) float64 { return a / b }, 1, 0.6},
+		{[]any{uint(1), uint(2)}, func(a, b float64) float64 { return a + b }, uint(0), uint(3)},
+	}
+
+	for _, test := range tests {
+		result := operateNumeric(test.values, test.op, test.initial)
+		assert.Equal(t, test.expected, result, "operateNumeric(%v, %v, %v) returned %v, expected %v", test.values, test.op, test.initial, result, test.expected)
+	}
+}

--- a/registry/slices/functions_test.go
+++ b/registry/slices/functions_test.go
@@ -22,6 +22,7 @@ func TestAppend(t *testing.T) {
 		{Input: `{{ append .V "a" }}`, Expected: "[a]", Data: map[string]any{"V": []string(nil)}},
 		{Input: `{{ append .V "a" }}`, Expected: "[]", Data: map[string]any{"V": nil}},
 		{Input: `{{ append .V "a" }}`, Expected: "[x a]", Data: map[string]any{"V": []string{"x"}}},
+		{Input: `{{ append .V "a" }}`, Expected: "[x a]", Data: map[string]any{"V": [1]string{"x"}}},
 	}
 
 	pesticide.RunTestCases(t, slices.NewRegistry(), tc)
@@ -33,6 +34,7 @@ func TestPrepend(t *testing.T) {
 		{Input: `{{ prepend .V "a" }}`, Expected: "[a]", Data: map[string]any{"V": []string(nil)}},
 		{Input: `{{ prepend .V "a" }}`, Expected: "[]", Data: map[string]any{"V": nil}},
 		{Input: `{{ prepend .V "a" }}`, Expected: "[a x]", Data: map[string]any{"V": []string{"x"}}},
+		{Input: `{{ prepend .V "a" }}`, Expected: "[a x]", Data: map[string]any{"V": [1]string{"x"}}},
 	}
 
 	pesticide.RunTestCases(t, slices.NewRegistry(), tc)
@@ -315,6 +317,8 @@ func TestMustSlice(t *testing.T) {
 		{TestCase: pesticide.TestCase{Input: `{{ mustSlice .V 0 1 }}`, Expected: "[a]", Data: map[string]any{"V": []string{"a", "b", "c", "d", "e"}}}, ExpectedErr: ""},
 		{TestCase: pesticide.TestCase{Input: `{{ mustSlice .V 0 1 }}`, Expected: "", Data: map[string]any{"V": nil}}, ExpectedErr: "cannot slice nil"},
 		{TestCase: pesticide.TestCase{Input: `{{ mustSlice .V 0 1 }}`, Expected: "", Data: map[string]any{"V": 1}}, ExpectedErr: "list should be type of slice or array but int"},
+		{TestCase: pesticide.TestCase{Input: `{{ mustSlice .V -1 1 }}`, Expected: "", Data: map[string]any{"V": []string{"a"}}}, ExpectedErr: "start index out of bounds"},
+		{TestCase: pesticide.TestCase{Input: `{{ mustSlice .V 0 52 }}`, Expected: "", Data: map[string]any{"V": []string{"a"}}}, ExpectedErr: "end index out of bounds"},
 	}
 
 	pesticide.RunMustTestCases(t, slices.NewRegistry(), tc)

--- a/registry/slices/helpers.go
+++ b/registry/slices/helpers.go
@@ -2,11 +2,27 @@ package slices
 
 import "reflect"
 
+// inList checks if a value is in a slice of any type by comparing values.
 func (sr *SlicesRegistry) inList(haystack []any, needle any) bool {
 	for _, h := range haystack {
-		if reflect.DeepEqual(needle, h) {
+		if sr.isComparable(h) && h == needle {
+			return true
+		}
+
+		if reflect.TypeOf(h) == reflect.TypeOf(needle) && reflect.DeepEqual(needle, h) {
 			return true
 		}
 	}
 	return false
+}
+
+// isComparable checks if a value is a comparable type.
+func (sr *SlicesRegistry) isComparable(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
+		float32, float64, string, bool:
+		return true
+	default:
+		return false
+	}
 }

--- a/registry/slices/helpers_test.go
+++ b/registry/slices/helpers_test.go
@@ -1,0 +1,57 @@
+package slices
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsComparable(t *testing.T) {
+	r := NewRegistry()
+
+	assert.True(t, r.isComparable(42))
+	assert.True(t, r.isComparable(42.0))
+	assert.True(t, r.isComparable("42"))
+	assert.True(t, r.isComparable(true))
+	assert.True(t, r.isComparable(`{"foo": "bar"}`))
+	assert.True(t, r.isComparable("foo: bar"))
+	assert.False(t, r.isComparable([]int{42}))
+	assert.False(t, r.isComparable(map[string]int{"foo": 42}))
+	assert.False(t, r.isComparable(struct{ Name string }{"example object"}))
+	assert.False(t, r.isComparable(func() string { return "example function" }))
+	assert.False(t, r.isComparable(fmt.Errorf("example error")))
+	assert.False(t, r.isComparable(time.Now()))
+	assert.False(t, r.isComparable(time.Second*5))
+	assert.False(t, r.isComparable(make(chan any)))
+	assert.False(t, r.isComparable(nil))
+
+}
+
+func TestSlicesRegistry_inList(t *testing.T) {
+	r := NewRegistry()
+
+	assert.True(t, r.inList([]any{1, 2, 3}, 2))
+	assert.True(t, r.inList([]any{1, 2, 3}, 3))
+	assert.False(t, r.inList([]any{1, 2, 3}, 4))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "b"))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "c"))
+	assert.False(t, r.inList([]any{"a", "b", "c"}, "d"))
+	assert.False(t, r.inList([]any{1, 2, 3}, 4.0))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "b"))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "c"))
+	assert.False(t, r.inList([]any{"a", "b", "c"}, "d"))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "b"))
+	assert.True(t, r.inList([]any{"a", "b", "c"}, "c"))
+
+	type testStruct struct{ Name string }
+	test := []testStruct{{"a"}, {"b"}, {"c"}}
+	var anyTest []any
+	for _, item := range test {
+		anyTest = append(anyTest, item)
+	}
+	assert.True(t, r.inList(anyTest, testStruct{"b"}))
+	assert.True(t, r.inList(anyTest, testStruct{"c"}))
+	assert.False(t, r.inList(anyTest, testStruct{"d"}))
+}

--- a/registry/std/functions.go
+++ b/registry/std/functions.go
@@ -41,7 +41,7 @@ func (sr *StdRegistry) Hello() string {
 //	{{ "first" | default "default" }} // Output: "first"
 //	{{ "first" | default "default" "second" }} // Output: "second"
 func (sr *StdRegistry) Default(defaultValue any, given ...any) any {
-	if helpers.Empty(given) || helpers.Empty(given[0]) {
+	if len(given) == 0 || helpers.Empty(given[0]) {
 		return defaultValue
 	}
 	return given[0]

--- a/registry/std/functions_test.go
+++ b/registry/std/functions_test.go
@@ -45,7 +45,7 @@ func TestEmpty(t *testing.T) {
 		{Name: "TestEmptyStructInput", Input: `{{if empty .s}}1{{else}}0{{end}}`, Expected: "0", Data: map[string]any{"s": struct{}{}}},
 		{Name: "TestEmptyNilInput", Input: `{{if empty nil}}1{{else}}0{{end}}`, Expected: "1"},
 		{Name: "TestEmptyNothingInput", Input: `{{if empty .Nothing}}1{{else}}0{{end}}`, Expected: "1"},
-		{Name: "TestEmptyNestedInput", Input: `{{if empty .top.NoSuchThing}}1{{else}}0{{end}}`, Expected: "1", Data: map[string]any{"top": map[string]interface{}{}}},
+		{Name: "TestEmptyNestedInput", Input: `{{if empty .top.NoSuchThing}}1{{else}}0{{end}}`, Expected: "1", Data: map[string]any{"top": map[string]any{}}},
 		{Name: "TestEmptyNestedNoDataInput", Input: `{{if empty .bottom.NoSuchThing}}1{{else}}0{{end}}`, Expected: "1"},
 		{Name: "TestEmptyNimPointerInput", Input: `{{if empty .nilPtr}}1{{else}}0{{end}}`, Expected: "1", Data: map[string]any{"nilPtr": (*int)(nil)}},
 	}
@@ -119,7 +119,7 @@ func TestCat(t *testing.T) {
 		{Name: "TestCatMultipleInput", Input: `{{cat "first" "second"}}`, Expected: "first second"},
 		{Name: "TestCatMultipleArgument", Input: `{{"first" | cat "second"}}`, Expected: "second first"},
 		{Name: "TestCatVariableInput", Input: `{{$b := "b"}}{{"c" | cat "a" $b}}`, Expected: "a b c"},
-		{Name: "TestCatDataInput", Input: `{{.text | cat "a" "b"}}`, Expected: "a b cd", Data: map[string]interface{}{"text": "cd"}},
+		{Name: "TestCatDataInput", Input: `{{.text | cat "a" "b"}}`, Expected: "a b cd", Data: map[string]any{"text": "cd"}},
 	}
 
 	pesticide.RunTestCases(t, std.NewRegistry(), tc)

--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -643,7 +643,7 @@ func (sr *StringsRegistry) Untitle(str string) string {
 	// Process each rune in the input string
 	startOfWord := true
 	for _, r := range str {
-		if r == ' ' {
+		if unicode.IsSpace(r) {
 			startOfWord = true
 			result.WriteRune(r)
 		} else {
@@ -740,17 +740,19 @@ func (sr *StringsRegistry) Splitn(sep string, n int, orig string) map[string]str
 //
 //	{{ "Hello World" | substring 0 5 }} // Output: "Hello"
 func (sr *StringsRegistry) Substring(start, end int, str string) string {
+	length := len(str)
+
 	if start < 0 {
-		start = len(str) + start
+		start = length + start
 	}
 	if end < 0 {
-		end = len(str) + end
+		end = length + end
 	}
 	if start < 0 {
 		start = 0
 	}
-	if end > len(str) {
-		end = len(str)
+	if end > length {
+		end = length
 	}
 	if start > end {
 		return ""
@@ -832,6 +834,14 @@ func (sr *StringsRegistry) Seq(params ...int) string {
 			increment = -1
 		}
 		return sr.convertIntArrayToString(helpers.UntilStep(start, end+increment, increment), " ")
+	case 2:
+		start := params[0]
+		end := params[1]
+		step := 1
+		if end < start {
+			step = -1
+		}
+		return sr.convertIntArrayToString(helpers.UntilStep(start, end+step, step), " ")
 	case 3:
 		start := params[0]
 		end := params[2]
@@ -843,14 +853,6 @@ func (sr *StringsRegistry) Seq(params ...int) string {
 			}
 		}
 		return sr.convertIntArrayToString(helpers.UntilStep(start, end+increment, step), " ")
-	case 2:
-		start := params[0]
-		end := params[1]
-		step := 1
-		if end < start {
-			step = -1
-		}
-		return sr.convertIntArrayToString(helpers.UntilStep(start, end+step, step), " ")
 	default:
 		return ""
 	}

--- a/registry/time/functions.go
+++ b/registry/time/functions.go
@@ -80,12 +80,18 @@ func (tr *TimeRegistry) DateInZone(fmt string, date any, zone string) string {
 func (tr *TimeRegistry) Duration(sec any) string {
 	var n int64
 	switch value := sec.(type) {
-	default:
-		n = 0
 	case string:
 		n, _ = strconv.ParseInt(value, 10, 64)
 	case int64:
 		n = value
+	case int:
+		n = int64(value)
+	case float64:
+		n = int64(value)
+	case float32:
+		n = int64(value)
+	default:
+		n = 0
 	}
 	return (time.Duration(n) * time.Second).String()
 }
@@ -191,11 +197,14 @@ func (tr *TimeRegistry) DateModify(fmt string, date time.Time) time.Time {
 //	{{ "3600s" | durationRound }} // Output: "1h"
 func (tr *TimeRegistry) DurationRound(duration any) string {
 	var d time.Duration
+
 	switch duration := duration.(type) {
 	case string:
 		d, _ = time.ParseDuration(duration)
 	case int64:
 		d = time.Duration(duration)
+	case time.Duration:
+		d = duration
 	case time.Time:
 		d = time.Since(duration)
 	default:
@@ -212,7 +221,7 @@ func (tr *TimeRegistry) DurationRound(duration any) string {
 		return "0s"
 	}
 
-	var (
+	const (
 		year   = uint64(time.Hour) * 24 * 365
 		month  = uint64(time.Hour) * 24 * 30
 		day    = uint64(time.Hour) * 24
@@ -227,6 +236,7 @@ func (tr *TimeRegistry) DurationRound(duration any) string {
 	if neg {
 		b.WriteByte('-')
 	}
+
 	switch {
 	case u > year:
 		b.WriteString(strconv.FormatUint(u/year, 10))

--- a/registry/time/functions_test.go
+++ b/registry/time/functions_test.go
@@ -40,7 +40,10 @@ func TestDateInZone(t *testing.T) {
 func TestDuration(t *testing.T) {
 	tc := []pesticide.TestCase{
 		{Name: "InvalidInput", Input: `{{ .V | duration }}`, Expected: "0s", Data: map[string]any{"V": "1h"}},
+		{Name: "TestDurationWithInt", Input: `{{ .V | duration }}`, Expected: "10s", Data: map[string]any{"V": int(10)}},
 		{Name: "TestDurationWithInt64", Input: `{{ .V | duration }}`, Expected: "10s", Data: map[string]any{"V": int64(10)}},
+		{Name: "TestDurationWithFloat32", Input: `{{ .V | duration }}`, Expected: "10s", Data: map[string]any{"V": float32(10)}},
+		{Name: "TestDurationWithFloat64", Input: `{{ .V | duration }}`, Expected: "10s", Data: map[string]any{"V": float64(10)}},
 		{Name: "TestDurationWithString", Input: `{{ .V | duration }}`, Expected: "26h3m4s", Data: map[string]any{"V": "93784"}},
 		{Name: "TestDurationWithInvalidType", Input: `{{ .V | duration }}`, Expected: "0s", Data: map[string]any{"V": make(chan int)}},
 	}
@@ -104,6 +107,7 @@ func TestDurationRound(t *testing.T) {
 		{Name: "RoundToMonth", Input: `{{ .V | durationRound }}`, Expected: "3mo", Data: map[string]any{"V": "2400h5s"}},
 		{Name: "RoundToMinute", Input: `{{ .V | durationRound }}`, Expected: "45m", Data: map[string]any{"V": int64(45*goTime.Minute + 30*goTime.Second)}},
 		{Name: "RoundToSecond", Input: `{{ .V | durationRound }}`, Expected: "1s", Data: map[string]any{"V": int64(1*goTime.Second + 500*goTime.Millisecond)}},
+		{Name: "RoundaDuration", Input: `{{ .V | durationRound }}`, Expected: "2s", Data: map[string]any{"V": 2 * goTime.Second}},
 		{Name: "RoundToYear", Input: `{{ .V | durationRound }}`, Expected: "1y", Data: map[string]any{"V": int64(365*24*goTime.Hour + 12*goTime.Hour)}},
 		{Name: "RoundToYearNegative", Input: `{{ .V | durationRound }}`, Expected: "1y", Data: map[string]any{"V": goTime.Now().Add(-365*24*goTime.Hour - 72*goTime.Hour)}},
 		{Name: "InvalidInput", Input: `{{ .V | durationRound }}`, Expected: "0s", Data: map[string]any{"V": make(chan int)}},

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -221,11 +221,11 @@ func HtmlFuncMap() htemplate.FuncMap {
 	return htemplate.FuncMap(FuncMap())
 }
 
-// GenericFuncMap returns a copy of the basic function map as a map[string]interface{}.
+// GenericFuncMap returns a copy of the basic function map as a map[string]any.
 // It provides backward compatibility with sprig.FuncMap and integrates
 // additional configured functions.
 // FOR BACKWARDS COMPATIBILITY ONLY
-func GenericFuncMap() map[string]interface{} {
+func GenericFuncMap() map[string]any {
 	return FuncMap()
 }
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -20,7 +20,7 @@ tasks:
       generate a benchmark report, a cpu profile and a memory profile.
     dir: ./benchmarks
     cmds:
-      - go test -run=^$$ -bench ^Benchmark -benchmem -cpuprofile cpu.out -memprofile mem.out
+      - go test -run=^$$ -bench ^Benchmark -benchmem -benchtime=250x -cpuprofile cpu.out -memprofile mem.out
   backwards:
     aliases: [back, bwd, compare]
     desc: Run the backwards compatibility tests between sprig and sprout


### PR DESCRIPTION
## Description
Aim to minimize memory allocations as much as possible to alleviate the burden on the garbage collector in large-scale applications. By optimizing the way memory is used within the framework, we ensure that Sprout is not only efficient in its functionality but also in its resource consumption. This approach contributes to overall better performance and scalability of applications using Sprout.

## Changes
- Reduce allocations over all functions
- Increase garbage-collector capacity over all functions
- Introduce a robust compare tool to ensure no breaking change are present between sprig and sprout

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information

Somes functions output are incorrect by definition in Sprig and Sprout fix that 🎉 
A list are presented in `SPRIG_TO_SPROUT_CHANGES_NOTES.md` and needs to be migrated in official documentation