### PR TITLE
feat: add notice on function call to inform or warn the end-users

### DIFF
--- a/benchmarks/comparaison_test.go
+++ b/benchmarks/comparaison_test.go
@@ -2,6 +2,7 @@ package benchmarks_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -52,6 +53,24 @@ var data = map[string]any{
 	"json":        `{"foo": "bar"}`,
 	"yaml":        "foo: bar",
 	"nil":         nil,
+}
+
+type noopHandler struct{}
+
+func (h *noopHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return false // Disable logging
+}
+
+func (h *noopHandler) Handle(_ context.Context, _ slog.Record) error {
+	return nil // Do nothing
+}
+
+func (h *noopHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *noopHandler) WithGroup(name string) slog.Handler {
+	return h
 }
 
 func BenchmarkComparison(b *testing.B) {
@@ -106,7 +125,7 @@ func sprigBench() {
  */
 func sproutBench(templatePath string) {
 	fnHandler := sprout.New(
-		sprout.WithLogger(slog.New(&slog.TextHandler{})),
+		sprout.WithLogger(slog.New(&noopHandler{})),
 	)
 
 	_ = fnHandler.AddRegistries(

--- a/notice.go
+++ b/notice.go
@@ -1,0 +1,177 @@
+package sprout
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type wrappedFunc = func(args ...any) (any, error)
+
+type NoticeKind int
+
+type FunctionNotice struct {
+	// FunctionNames is a list of function names to which the notice should be
+	// applied. The function names are case-sensitive.
+	FunctionNames []string
+
+	// Kind is the kind of the notice
+	Kind NoticeKind
+
+	// Message is the message of the notice
+	Message string
+}
+
+const (
+	// NoticeKindDeprecated indicates that the function is deprecated.
+	NoticeKindDeprecated NoticeKind = iota + 1
+	// NoticeKindInfo indicates that the notice is informational.
+	NoticeKindInfo
+	// NoticeKindDebug indicates that the notice is for debugging purposes.
+	// When using this kind, the notice message can contain the "$out" placeholder
+	// which will be replaced with the output of the function.
+	NoticeKindDebug
+)
+
+// NewNotice creates a new function notice with the given function name, kind,
+// and message. The function name is case-sensitive. The kind should be one of
+// the predefined NoticeKind values. The message is a string that describes the
+// notice.
+//
+// Example:
+//
+//	notice := NewNotice(NoticeKindDeprecated, "myFunc", "please use myNewFunc instead")
+//
+// This example creates a new notice that indicates the function "myFunc" is
+// deprecated and should be replaced with "myNewFunc" during template rendering.
+func NewNotice(kind NoticeKind, functionNames []string, message string) *FunctionNotice {
+	return &FunctionNotice{
+		FunctionNames: functionNames,
+		Kind:          kind,
+		Message:       message,
+	}
+}
+
+// NewDeprecatedNotice creates a new deprecated function notice with the given
+// function name and message. The function name is case-sensitive. The message
+// is a string that describes what the user should do instead of using the
+// deprecated function.
+func NewDeprecatedNotice(functionName, message string) *FunctionNotice {
+	return NewNotice(NoticeKindDeprecated, []string{functionName}, message)
+}
+
+// NewInfoNotice creates a new information function notice with the given
+// function name and message. The function name is case-sensitive. The message
+// is a string that provides additional informatio
+func NewInfoNotice(functionName, message string) *FunctionNotice {
+	return NewNotice(NoticeKindInfo, []string{functionName}, message)
+}
+
+// AssignNotices assigns all notices defined in the handler to their original
+// functions. This function is used to ensure that all notices are properly
+// associated with their original functions in the handler instance.
+//
+// It should be called after all functions and notices have been added and
+// inside the Build function in case of using a custom handler.
+func AssignNotices(h Handler) {
+	funcs := h.Functions()
+	for _, notice := range h.Notices() {
+		for _, functionName := range notice.FunctionNames {
+			if fn, ok := funcs[functionName]; ok {
+				wrappedFn := createWrappedFunction(h, notice, functionName, fn)
+				funcs[functionName] = wrappedFn
+			}
+		}
+	}
+}
+
+// createWrappedFunction creates a wrapped function that logs a notice after
+// calling the original function. The notice is logged using the handler's
+// logger instance. The wrapped function is returned as a HandlerFunc.
+func createWrappedFunction(h Handler, notice FunctionNotice, functionName string, fn any) wrappedFunc {
+	return func(args ...any) (any, error) {
+		out, err := safeCall(fn, args...)
+		switch notice.Kind {
+		case NoticeKindDebug:
+			h.Logger().With("function", functionName, "notice", "debug").Debug(strings.ReplaceAll(notice.Message, "$out", fmt.Sprint(out)))
+		case NoticeKindInfo:
+			h.Logger().With("function", functionName, "notice", "info").Info(notice.Message)
+		case NoticeKindDeprecated:
+			h.Logger().With("function", functionName, "notice", "deprecated").Warn(fmt.Sprintf("Template function `%s` is deprecated: %s", functionName, notice.Message))
+		}
+		return out, err
+	}
+}
+
+// WithNotices is used to add one or more function notices to the handler.
+// This option allows you to associate a notice with a function, providing
+// information about the function's deprecation or other special handling.
+//
+// The notices are applied to the original function name and its aliases.
+// You can use the ApplyOnAliases method on the FunctionNotice to control
+// whether the notice should be applied to aliases.
+func WithNotices(notices ...*FunctionNotice) HandlerOption[*DefaultHandler] {
+	return func(p *DefaultHandler) {
+		// Preallocate the slice if we expect to append multiple notices
+		if cap(p.notices) < len(p.notices)+len(notices) {
+			newNotices := make([]FunctionNotice, len(p.notices), len(p.notices)+len(notices))
+			copy(newNotices, p.notices)
+			p.notices = newNotices
+		}
+
+		for _, notice := range notices {
+			// Skip if the function name is empty or the kind is not valid
+			if len(notice.FunctionNames) == 0 || notice.Kind <= 0 {
+				continue
+			}
+
+			// Append the notice directly without dereferencing
+			p.notices = append(p.notices, *notice)
+		}
+	}
+}
+
+func safeCall(fn any, args ...any) (result any, err error) {
+	// Ensure fn is a function
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		return nil, errors.New("fn is not a function")
+	}
+
+	// Defer a function to handle panics
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered from panic: %v", r)
+		}
+	}()
+
+	// Convert args to reflect.Value slice
+	in := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		in[i] = reflect.ValueOf(arg)
+	}
+
+	// Call the function using reflection
+	out := v.Call(in)
+
+	// Process the output
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	// If there's only one return value
+	result = out[0].Interface()
+	if len(out) == 1 {
+		return result, nil
+	}
+
+	// If there are two return values (assuming the second is an error)
+	if len(out) == 2 && out[1].Type().Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+		err, _ = out[1].Interface().(error)
+		return result, err
+	}
+
+	// Handle other cases as needed
+	return result, nil
+}

--- a/notice.go
+++ b/notice.go
@@ -68,6 +68,15 @@ func NewInfoNotice(functionName, message string) *FunctionNotice {
 	return NewNotice(NoticeKindInfo, []string{functionName}, message)
 }
 
+// NewDebugNotice creates a new debug function notice with the given function
+// name and message. The function name is case-sensitive. The message is a
+// string that provides additional information for debugging purposes. The
+// message can contain the "$out" placeholder which will be replaced with the
+// output of the function.
+func NewDebugNotice(functionName, message string) *FunctionNotice {
+	return NewNotice(NoticeKindDebug, []string{functionName}, message)
+}
+
 // AssignNotices assigns all notices defined in the handler to their original
 // functions. This function is used to ensure that all notices are properly
 // associated with their original functions in the handler instance.

--- a/notice_test.go
+++ b/notice_test.go
@@ -1,0 +1,190 @@
+package sprout
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noticeLoggerHandler struct {
+	messages bytes.Buffer
+}
+
+func (h *noticeLoggerHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return true
+}
+
+func (h *noticeLoggerHandler) Handle(_ context.Context, r slog.Record) error {
+	msg := fmt.Sprintf("[%s] %s\n", r.Level.String(), r.Message)
+	h.messages.Write([]byte(msg))
+	return nil
+}
+
+func (h *noticeLoggerHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *noticeLoggerHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+func TestWithNotice(t *testing.T) {
+	handler := New()
+	originalFunc := "originalFunc"
+	notice := NewInfoNotice(originalFunc, "amazing")
+
+	// Apply the WithNotices option with one notice.
+	WithNotices(notice)(handler)
+
+	// Check that the aliases were added.
+	assert.Contains(t, handler.Notices(), *notice)
+	assert.Len(t, handler.notices, 1, "there should be exactly 1 notice")
+
+	// Apply the WithNotices option with multiple notices.
+	notice2 := NewDeprecatedNotice(originalFunc, "oh no")
+	WithNotices(notice, notice2)(handler)
+
+	// Check that the aliases were added.
+	assert.Contains(t, handler.Notices(), *notice)
+	assert.Contains(t, handler.Notices(), *notice2)
+	assert.Len(t, handler.notices, 3, "there should be exactly 3 notices")
+
+	// Try to apply a notice with an empty function name.
+	notice3 := &FunctionNotice{}
+	WithNotices(notice3)(handler)
+
+	// Check that the aliases were not added.
+	assert.NotContains(t, handler.Notices(), *notice3)
+	assert.Len(t, handler.notices, 3, "there should still be exactly 3 notices")
+}
+
+func TestAssignNotices(t *testing.T) {
+	handler := New()
+	originalFunc := "originalFunc"
+	notice := NewInfoNotice(originalFunc, "amazing")
+
+	// Mock a function for originalFunc and add it to funcsRegistry.
+	mockFunc := func() string { return "cheese" }
+	handler.cachedFuncsMap[originalFunc] = mockFunc
+
+	// Assign the notices directly.
+	handler.notices = []FunctionNotice{*notice}
+	AssignNotices(handler)
+
+	// Check that the aliases were added.
+	assert.Contains(t, handler.Notices(), *notice)
+	assert.Len(t, handler.notices, 1, "there should be exactly 1 notice")
+
+	require.Contains(t, handler.Functions(), originalFunc)
+	assert.NotEqual(t, reflect.ValueOf(mockFunc).Pointer(), reflect.ValueOf(handler.Functions()[originalFunc]).Pointer(), "the function should have been wrapped")
+}
+
+func TestCreateWrappedFunction(t *testing.T) {
+	loggerHandler := &noticeLoggerHandler{}
+	handler := New(WithLogger(slog.New(loggerHandler)))
+
+	originalFunc := "originalFunc"
+	mockFunc := func() string { return "cheese" }
+
+	// Create a wrapped function.
+	wrappedFunc := createWrappedFunction(handler, *NewInfoNotice(originalFunc, "amazing"), originalFunc, mockFunc)
+	wrappedFunc2 := createWrappedFunction(handler, *NewDeprecatedNotice(originalFunc, "oh no"), originalFunc, mockFunc)
+	wrappedFunc3 := createWrappedFunction(handler, *NewNotice(NoticeKindDebug, []string{originalFunc}, "Nice this function returns $out"), originalFunc, mockFunc)
+
+	// Call the wrapped function.
+	out, err := wrappedFunc()
+	assert.NoError(t, err)
+	assert.Equal(t, "cheese", out)
+	assert.Contains(t, loggerHandler.messages.String(), "[INFO] amazing")
+
+	out, err = wrappedFunc2()
+	assert.NoError(t, err)
+	assert.Equal(t, "cheese", out)
+	assert.Contains(t, loggerHandler.messages.String(), "[WARN] Template function `originalFunc` is deprecated: oh no")
+
+	out, err = wrappedFunc3()
+	assert.NoError(t, err)
+	assert.Equal(t, "cheese", out)
+	assert.Contains(t, loggerHandler.messages.String(), "[DEBUG] Nice this function returns cheese")
+}
+
+func TestSafeCall(t *testing.T) {
+	// Test a function that returns a string.
+	fn := func() (string, error) { return "cheese", nil }
+	out, err := safeCall(fn)
+	assert.NoError(t, err)
+	assert.Equal(t, "cheese", out)
+
+	// Test a function that returns a string and an error.
+	fn2 := func() (string, error) { return "cheese", fmt.Errorf("oh no") }
+	out, err = safeCall(fn2)
+	assert.Error(t, err)
+	assert.Equal(t, "cheese", out)
+
+	// Test a function that returns a string and an error.
+	fn3 := func() (string, error) { return "", fmt.Errorf("oh no") }
+	out, err = safeCall(fn3)
+	assert.Error(t, err)
+	assert.Empty(t, out)
+
+	// Test a function that returns a string and an error.
+	fn4 := func() (string, error) { return "", nil }
+	out, err = safeCall(fn4)
+	assert.NoError(t, err)
+	assert.Empty(t, out)
+
+	// Test a function that returns nothing.
+	fn5 := func() {}
+	out, err = safeCall(fn5)
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+
+	// Test a function that returns 3 values.
+	a, b, c := "a", "b", "c"
+	fn6 := func(a, b, c string) (string, string, string) { return a, b, c }
+	out, err = safeCall(fn6, a, b, c)
+	assert.NoError(t, err)
+	assert.Equal(t, out, a, "the return should be the first argument")
+
+	// Test a case where the function panics.
+	fn7 := func() { panic("oh no") }
+	out, err = safeCall(fn7)
+	assert.ErrorContains(t, err, "recovered from panic: oh no")
+	assert.Nil(t, out)
+
+	// Test when fn is not a function.
+	fn8 := "cheese"
+	out, err = safeCall(fn8)
+	assert.ErrorContains(t, err, "fn is not a function")
+	assert.Nil(t, out)
+}
+
+func TestNoticeInTemplate(t *testing.T) {
+	loggerHandler := &noticeLoggerHandler{}
+	handler := New(WithLogger(slog.New(loggerHandler)))
+
+	originalFunc := "originalFunc"
+	mockFunc := func() string { return "cheese" }
+	handler.cachedFuncsMap[originalFunc] = mockFunc
+
+	// Add a notice to the handler.
+	AddNotice(&handler.notices, NewInfoNotice(originalFunc, "amazing"))
+
+	// Create a template with the function.
+	tmpl, err := template.New("test").Funcs(handler.Build()).Parse("{{- originalFunc -}}")
+	require.NoError(t, err)
+
+	// Execute the template.
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cheese", buf.String())
+	assert.Equal(t, loggerHandler.messages.String(), "[INFO] amazing\n")
+}

--- a/notice_test.go
+++ b/notice_test.go
@@ -56,13 +56,22 @@ func TestWithNotice(t *testing.T) {
 	assert.Contains(t, handler.Notices(), *notice2)
 	assert.Len(t, handler.notices, 3, "there should be exactly 3 notices")
 
-	// Try to apply a notice with an empty function name.
-	notice3 := &FunctionNotice{}
+	// Apply the WithNotices option with an empty message
+	notice3 := NewDebugNotice(originalFunc, "")
 	WithNotices(notice3)(handler)
 
+	assert.Contains(t, handler.Notices(), *notice)
+	assert.Contains(t, handler.Notices(), *notice2)
+	assert.Contains(t, handler.Notices(), *notice3)
+	assert.Len(t, handler.notices, 4, "there should be exactly 3 notices")
+
+	// Try to apply a notice with an empty function name.
+	notice4 := &FunctionNotice{}
+	WithNotices(notice4)(handler)
+
 	// Check that the aliases were not added.
-	assert.NotContains(t, handler.Notices(), *notice3)
-	assert.Len(t, handler.notices, 3, "there should still be exactly 3 notices")
+	assert.NotContains(t, handler.Notices(), *notice4)
+	assert.Len(t, handler.notices, 4, "there should still be exactly 3 notices")
 }
 
 func TestAssignNotices(t *testing.T) {

--- a/registry.go
+++ b/registry.go
@@ -33,6 +33,12 @@ type RegistryWithAlias interface {
 	RegisterAliases(aliasMap FunctionAliasMap) error
 }
 
+type RegistryWithNotice interface {
+	// RegisterNotices adds the provided notices into the given notice list.
+	// This method is called by an Handler to register all notices of a registry.
+	RegisterNotices(notices *[]FunctionNotice) error
+}
+
 // AddFunction adds a new function under the specified name to the given registry.
 // If the function name already exists in the registry, this method does nothing to
 // prevent accidental overwriting of existing registered functions.
@@ -56,4 +62,9 @@ func AddAlias(aliasMap FunctionAliasMap, originalFunction string, aliases ...str
 	}
 
 	aliasMap[originalFunction] = append(aliasMap[originalFunction], aliases...)
+}
+
+// AddNotice adds a new function notice to the given function
+func AddNotice(notices *[]FunctionNotice, notice *FunctionNotice) {
+	*notices = append(*notices, *notice)
 }

--- a/registry/numeric/numeric.go
+++ b/registry/numeric/numeric.go
@@ -1,6 +1,8 @@
 package numeric
 
-import "github.com/go-sprout/sprout"
+import (
+	"github.com/go-sprout/sprout"
+)
 
 // numericOperation defines a function type that performs a binary operation on
 // two float64 values. It is used to abstract arithmetic operations like

--- a/registry/numeric/numeric.go
+++ b/registry/numeric/numeric.go
@@ -60,3 +60,10 @@ func (nr *NumericRegistry) RegisterAliases(aliasMap sprout.FunctionAliasMap) err
 	sprout.AddAlias(aliasMap, "sub", "subf")
 	return nil
 }
+
+func (nr *NumericRegistry) RegisterNotices(notices *[]sprout.FunctionNotice) error {
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("addf", "please use `add` instead"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("add1f", "please use `add1` instead"))
+	sprout.AddNotice(notices, sprout.NewDeprecatedNotice("subf", "please use `sub` instead"))
+	return nil
+}

--- a/sprout.go
+++ b/sprout.go
@@ -31,6 +31,7 @@ func New(opts ...HandlerOption[*DefaultHandler]) *DefaultHandler {
 	dh := &DefaultHandler{
 		logger:     slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		registries: make([]Registry, 0),
+		notices:    make([]FunctionNotice, 0),
 
 		cachedFuncsMap:   make(FunctionMap),
 		cachedFuncsAlias: make(FunctionAliasMap),


### PR DESCRIPTION
## Description
When you are a middle-app (between sprout and the user how write the template), you need to be careful when you upgrade a template library due to potential breaking changes or deprecated functions. This solution let developer be stress less about upgrade of sprout 🌱

## Changes
- Add notice feature
- Add notice on numeric registry
- Add notice on sprigin package

## Fixes #57 

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information
Example of output using a custom `slog.Logger`
![image](https://github.com/user-attachments/assets/de5444ab-d150-4e17-a7a2-91d0a51fe4e6)
