### PR TITLE
feat: add `hasField` method for use with structs

### DIFF
--- a/docs/registries/reflect.md
+++ b/docs/registries/reflect.md
@@ -90,6 +90,24 @@ The function returns the kind (category) of the provided value (`src`) as a stri
 {% endtab %}
 {% endtabs %}
 
+### <mark style="color:purple;">hasField</mark>
+
+The function checks the presence of a field with the specified name (`name`) in the provided struct (`src`). It returns `true` if the field exists.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">HasField(name string, src any) bool
+</code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ hasField "someExistingField" .someStruct }} // Output: true
+{{ hasField "someNonExistingField" .someStruct }} // Output: false
+{{ .someStruct | hasField "someExistingField" }} // Output: true
+{{ .someStruct | hasField "someNonExistingField" }} // Output: false
+```
+{% endtab %}
+{% endtabs %}
+
 ### <mark style="color:purple;">deepEqual</mark>
 
 The function checks if two variables, `x` and `y`, are deeply equal by comparing their values and structures using `reflect.DeepEqual`.
@@ -124,22 +142,6 @@ MustDeepCopy(element any) (any, error)
 ```go
 {{ {"name":"John"} | mustDeepCopy }} // Output: {"name":"John"}
 {{ nil | mustDeepCopy }} // Output: nil, error
-```
-{% endtab %}
-{% endtabs %}
-
-### <mark style="color:purple;">hasField</mark>
-
-The function checks the struct `s` for the presence of a field with the name `name`, returning `true` if the field is present and `false` otherwise.
-
-<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">HasField(s any, name string) bool
-</code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
-
-{% tabs %}
-{% tab title="Template Example" %}
-```go
-{{ hasField .someStruct "someExistingField" }} // Output: true
-{{ hasField .someStruct "someNonExistingField" }} // Output: false
 ```
 {% endtab %}
 {% endtabs %}

--- a/docs/registries/reflect.md
+++ b/docs/registries/reflect.md
@@ -127,3 +127,19 @@ MustDeepCopy(element any) (any, error)
 ```
 {% endtab %}
 {% endtabs %}
+
+### <mark style="color:purple;">hasField</mark>
+
+The function checks the struct `s` for the presence of a field with the name `name`, returning `true` if the field is present and `false` otherwise.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">HasField(s any, name string) bool
+</code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ hasField .someStruct "someExistingField" }} // Output: true
+{{ hasField .someStruct "someNonExistingField" }} // Output: false
+```
+{% endtab %}
+{% endtabs %}

--- a/registry/reflect/functions.go
+++ b/registry/reflect/functions.go
@@ -149,3 +149,26 @@ func (rr *ReflectRegistry) MustDeepCopy(element any) (any, error) {
 	}
 	return copystructure.Copy(element)
 }
+
+// HasField checks whether a struct has a field with a given name.
+//
+// Parameters:
+//
+//	s any - the struct that is being checked.
+//	name string - the name of the field that is being checked.
+//
+// Returns:
+//
+//	bool - true if the struct 's' contains a field with the name 'name', false otherwise.
+//
+// Example:
+//
+//	{{ hasField .someStruct "someExistingField" }} // Output: true
+//	{{ hasField .someStruct "someNonExistingField" }} // Output: false
+func (rr *ReflectRegistry) HasField(s any, name string) bool {
+	rv := reflect.Indirect(reflect.ValueOf(s))
+	if rv.Kind() != reflect.Struct {
+		return false
+	}
+	return rv.FieldByName(name).IsValid()
+}

--- a/registry/reflect/functions.go
+++ b/registry/reflect/functions.go
@@ -111,7 +111,7 @@ func (rr *ReflectRegistry) KindOf(src any) string {
 //
 // Returns:
 //
-//	bool - true if the struct 's' contains a field with the name 'name', false otherwise.
+//	bool - true if the struct 'src' contains a field with the name 'name', false otherwise.
 //
 // Example:
 //

--- a/registry/reflect/functions.go
+++ b/registry/reflect/functions.go
@@ -102,6 +102,29 @@ func (rr *ReflectRegistry) KindOf(src any) string {
 	return reflect.ValueOf(src).Kind().String()
 }
 
+// HasField checks whether a struct has a field with a given name.
+//
+// Parameters:
+//
+//	name string - the name of the field that is being checked.
+//	src any - the struct that is being checked.
+//
+// Returns:
+//
+//	bool - true if the struct 's' contains a field with the name 'name', false otherwise.
+//
+// Example:
+//
+//	{{ hasField "someExistingField" .someStruct }} // Output: true
+//	{{ hasField "someNonExistingField" .someStruct }} // Output: false
+func (rr *ReflectRegistry) HasField(name string, src any) bool {
+	rv := reflect.Indirect(reflect.ValueOf(src))
+	if rv.Kind() != reflect.Struct {
+		return false
+	}
+	return rv.FieldByName(name).IsValid()
+}
+
 // DeepEqual determines if two variables, 'x' and 'y', are deeply equal.
 // It uses reflect.DeepEqual to evaluate equality.
 //
@@ -148,27 +171,4 @@ func (rr *ReflectRegistry) MustDeepCopy(element any) (any, error) {
 		return nil, errors.New("element cannot be nil")
 	}
 	return copystructure.Copy(element)
-}
-
-// HasField checks whether a struct has a field with a given name.
-//
-// Parameters:
-//
-//	s any - the struct that is being checked.
-//	name string - the name of the field that is being checked.
-//
-// Returns:
-//
-//	bool - true if the struct 's' contains a field with the name 'name', false otherwise.
-//
-// Example:
-//
-//	{{ hasField .someStruct "someExistingField" }} // Output: true
-//	{{ hasField .someStruct "someNonExistingField" }} // Output: false
-func (rr *ReflectRegistry) HasField(s any, name string) bool {
-	rv := reflect.Indirect(reflect.ValueOf(s))
-	if rv.Kind() != reflect.Struct {
-		return false
-	}
-	return rv.FieldByName(name).IsValid()
 }

--- a/registry/reflect/functions_test.go
+++ b/registry/reflect/functions_test.go
@@ -123,3 +123,29 @@ func TestDeepCopy(t *testing.T) {
 		})
 	}
 }
+
+func TestHasField(t *testing.T) {
+	type A struct {
+		Foo string
+	}
+	type B struct {
+		Bar string
+	}
+	const tpl = `{{if hasField .sut "Foo"}}SUT has Foo.{{else}}SUT has no Foo.{{end}}`
+	var tc = []pesticide.TestCase{
+		{Name: "TestHasFieldStructTrue", Input: tpl, Expected: "SUT has Foo.", Data: map[string]any{"sut": &A{Foo: "Lorem"}}},
+		{Name: "TestHasFieldStructFalse", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": &B{Bar: "Ipsum"}}},
+		{Name: "TestHasFieldInt", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": 123}},
+		{Name: "TestHasFieldMap", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": map[string]string{"Foo": "bar"}}},
+		{Name: "TestHasFieldSlice", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": []int{1, 2, 3}}},
+		{Name: "TestHasFieldString", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": "foobar"}},
+		{Name: "TestHasFieldNil", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": nil}},
+	}
+	for _, test := range tc {
+		t.Run(test.Name, func(t *testing.T) {
+			tmplResponse, err := pesticide.TestTemplate(t, reflect.NewRegistry(), test.Input, test.Data)
+			assert.NoError(t, err)
+			assert.Equal(t, test.Expected, tmplResponse)
+		})
+	}
+}

--- a/registry/reflect/functions_test.go
+++ b/registry/reflect/functions_test.go
@@ -76,6 +76,29 @@ func TestKindOf(t *testing.T) {
 	pesticide.RunTestCases(t, reflect.NewRegistry(), tc)
 }
 
+func TestHasField(t *testing.T) {
+	type A struct {
+		Foo string
+	}
+	type B struct {
+		Bar string
+	}
+
+	var tc = []pesticide.TestCase{
+		{Name: "TestHasFieldStructPointerTrue", Input: `{{ .V |hasField "Foo" }}`, Expected: "true", Data: map[string]any{"V": &A{Foo: "bar"}}},
+		{Name: "TestHasFieldStructPointerFalse", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": &B{Bar: "boo"}}},
+		{Name: "TestHasFieldStructTrue", Input: `{{ .V |hasField "Foo" }}`, Expected: "true", Data: map[string]any{"V": A{Foo: "bar"}}},
+		{Name: "TestHasFieldStructFalse", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": B{Bar: "boo"}}},
+		{Name: "TestHasFieldInt", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": 123}},
+		{Name: "TestHasFieldMap", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": map[string]string{"Foo": "bar"}}},
+		{Name: "TestHasFieldSlice", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": []int{1, 2, 3}}},
+		{Name: "TestHasFieldString", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": "foobar"}},
+		{Name: "TestHasFieldNil", Input: `{{ .V |hasField "Foo" }}`, Expected: "false", Data: map[string]any{"V": nil}},
+	}
+
+	pesticide.RunTestCases(t, reflect.NewRegistry(), tc)
+}
+
 func TestDeepEqual(t *testing.T) {
 	var tc = []pesticide.TestCase{
 		{Name: "TestDeepEqualInt", Input: `{{deepEqual 42 42}}`, Expected: "true"},
@@ -120,32 +143,6 @@ func TestDeepCopy(t *testing.T) {
 			if test.Data != nil {
 				assert.NotEqual(t, test.Data["a"], test.Expected)
 			}
-		})
-	}
-}
-
-func TestHasField(t *testing.T) {
-	type A struct {
-		Foo string
-	}
-	type B struct {
-		Bar string
-	}
-	const tpl = `{{if hasField .sut "Foo"}}SUT has Foo.{{else}}SUT has no Foo.{{end}}`
-	var tc = []pesticide.TestCase{
-		{Name: "TestHasFieldStructTrue", Input: tpl, Expected: "SUT has Foo.", Data: map[string]any{"sut": &A{Foo: "Lorem"}}},
-		{Name: "TestHasFieldStructFalse", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": &B{Bar: "Ipsum"}}},
-		{Name: "TestHasFieldInt", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": 123}},
-		{Name: "TestHasFieldMap", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": map[string]string{"Foo": "bar"}}},
-		{Name: "TestHasFieldSlice", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": []int{1, 2, 3}}},
-		{Name: "TestHasFieldString", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": "foobar"}},
-		{Name: "TestHasFieldNil", Input: tpl, Expected: "SUT has no Foo.", Data: map[string]any{"sut": nil}},
-	}
-	for _, test := range tc {
-		t.Run(test.Name, func(t *testing.T) {
-			tmplResponse, err := pesticide.TestTemplate(t, reflect.NewRegistry(), test.Input, test.Data)
-			assert.NoError(t, err)
-			assert.Equal(t, test.Expected, tmplResponse)
 		})
 	}
 }

--- a/registry/reflect/reflect.go
+++ b/registry/reflect/reflect.go
@@ -23,14 +23,15 @@ func (rr *ReflectRegistry) LinkHandler(fh sprout.Handler) error {
 }
 
 // RegisterFunctions registers all functions of the registry.
-func (nr *ReflectRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
-	sprout.AddFunction(funcsMap, "typeIs", nr.TypeIs)
-	sprout.AddFunction(funcsMap, "typeIsLike", nr.TypeIsLike)
-	sprout.AddFunction(funcsMap, "typeOf", nr.TypeOf)
-	sprout.AddFunction(funcsMap, "kindIs", nr.KindIs)
-	sprout.AddFunction(funcsMap, "kindOf", nr.KindOf)
-	sprout.AddFunction(funcsMap, "deepEqual", nr.DeepEqual)
-	sprout.AddFunction(funcsMap, "deepCopy", nr.DeepCopy)
-	sprout.AddFunction(funcsMap, "mustDeepCopy", nr.MustDeepCopy)
+func (rr *ReflectRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
+	sprout.AddFunction(funcsMap, "typeIs", rr.TypeIs)
+	sprout.AddFunction(funcsMap, "typeIsLike", rr.TypeIsLike)
+	sprout.AddFunction(funcsMap, "typeOf", rr.TypeOf)
+	sprout.AddFunction(funcsMap, "kindIs", rr.KindIs)
+	sprout.AddFunction(funcsMap, "kindOf", rr.KindOf)
+	sprout.AddFunction(funcsMap, "deepEqual", rr.DeepEqual)
+	sprout.AddFunction(funcsMap, "deepCopy", rr.DeepCopy)
+	sprout.AddFunction(funcsMap, "mustDeepCopy", rr.MustDeepCopy)
+	sprout.AddFunction(funcsMap, "hasField", rr.HasField)
 	return nil
 }

--- a/registry/reflect/reflect.go
+++ b/registry/reflect/reflect.go
@@ -29,9 +29,9 @@ func (rr *ReflectRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error 
 	sprout.AddFunction(funcsMap, "typeOf", rr.TypeOf)
 	sprout.AddFunction(funcsMap, "kindIs", rr.KindIs)
 	sprout.AddFunction(funcsMap, "kindOf", rr.KindOf)
+	sprout.AddFunction(funcsMap, "hasField", rr.HasField)
 	sprout.AddFunction(funcsMap, "deepEqual", rr.DeepEqual)
 	sprout.AddFunction(funcsMap, "deepCopy", rr.DeepCopy)
 	sprout.AddFunction(funcsMap, "mustDeepCopy", rr.MustDeepCopy)
-	sprout.AddFunction(funcsMap, "hasField", rr.HasField)
 	return nil
 }


### PR DESCRIPTION
## Description
Closes #60 

## Changes
The PR introduces a `hasField` method to the `reflect` registry, to address the use case explained in #60.
<!--
- Detail the changes you have introduced.
- Highlight any new functionality.
-->

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.
