### PR TITLE
feat: add strings capitalization functions

### DIFF
--- a/docs/registries/strings.md
+++ b/docs/registries/strings.md
@@ -531,6 +531,8 @@ Uppercases the first letter of a string while leaving the rest of the string unc
 {% tab title="Template Example" %}
 ```go
 {{ "hello world" | capitalize }} // Output: "Hello world"
+{{ "123boo_bar" | capitalize }} // Output: 123Boo_bar
+{{ " Fe bar" | capitalize }} // Output: " Fe bar"
 ```
 {% endtab %}
 {% endtabs %}
@@ -546,6 +548,8 @@ Lowercases the first letter of a string while leaving the rest of the string unc
 {% tab title="Template Example" %}
 ```go
 {{ "Hello World" | uncapitalize }} // Output: "hello World"
+{{ "123Boo_bar" | uncapitalize }} // Output: 123boo_bar
+{{ " Fe bar" | uncapitalize }} // Output: " fe bar"
 ```
 {% endtab %}
 {% endtabs %}

--- a/docs/registries/strings.md
+++ b/docs/registries/strings.md
@@ -520,6 +520,36 @@ Switches the case of each letter in a string, converting lowercase to uppercase 
 {% endtab %}
 {% endtabs %}
 
+### <mark style="color:purple;">capitalize</mark>
+
+Uppercases the first letter of a string while leaving the rest of the string unchanged.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">capitalize(str string) string
+</code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "hello world" | capitalize }} // Output: "Hello world"
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">uncapitalize</mark>
+
+Lowercases the first letter of a string while leaving the rest of the string unchanged.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">uncapitalize(str string) string
+</code></pre></td></tr><tr><td>Must version</td><td><span data-gb-custom-inline data-tag="emoji" data-code="274c">❌</span></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "Hello World" | uncapitalize }} // Output: "hello World"
+```
+{% endtab %}
+{% endtabs %}
+
 ### <mark style="color:purple;">split</mark>
 
 Divides a string into a map of parts based on a specified separator, returning a collection of the split components.

--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -682,6 +682,60 @@ func (sr *StringsRegistry) SwapCase(str string) string {
 	}, str)
 }
 
+// Capitalize capitalizes the first letter of 'str'.
+//
+// Parameters:
+//
+//	str string - the string to capitalize.
+//
+// Returns:
+//
+//	string - the string with the first letter capitalized.
+//
+// Example:
+//
+//	{{ "hello world" | capitalize }} // Output: "Hello world"
+func (sr *StringsRegistry) Capitalize(str string) string {
+	if str == "" {
+		return ""
+	}
+
+	for i, r := range str {
+		if unicode.IsLetter(r) {
+			return str[:i] + string(unicode.ToUpper(r)) + str[i+1:]
+		}
+	}
+
+	return str
+}
+
+// Uncapitalize converts the first letter of 'str' to lowercase.
+//
+// Parameters:
+//
+//	str string - the string to uncapitalize.
+//
+// Returns:
+//
+//	string - the string with the first letter in lowercase.
+//
+// Example:
+//
+//	{{ "Hello World" | uncapitalize }} // Output: "hello World"
+func (sr *StringsRegistry) Uncapitalize(str string) string {
+	if str == "" {
+		return ""
+	}
+
+	for i, r := range str {
+		if unicode.IsLetter(r) {
+			return str[:i] + string(unicode.ToLower(r)) + str[i+1:]
+		}
+	}
+
+	return str
+}
+
 // Split divides 'orig' into a map of string parts using 'sep' as the separator.
 //
 // Parameters:

--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -696,10 +696,6 @@ func (sr *StringsRegistry) SwapCase(str string) string {
 //
 //	{{ "hello world" | capitalize }} // Output: "Hello world"
 func (sr *StringsRegistry) Capitalize(str string) string {
-	if str == "" {
-		return ""
-	}
-
 	for i, r := range str {
 		if unicode.IsLetter(r) {
 			return str[:i] + string(unicode.ToUpper(r)) + str[i+1:]
@@ -723,10 +719,6 @@ func (sr *StringsRegistry) Capitalize(str string) string {
 //
 //	{{ "Hello World" | uncapitalize }} // Output: "hello World"
 func (sr *StringsRegistry) Uncapitalize(str string) string {
-	if str == "" {
-		return ""
-	}
-
 	for i, r := range str {
 		if unicode.IsLetter(r) {
 			return str[:i] + string(unicode.ToLower(r)) + str[i+1:]

--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -428,7 +428,7 @@ func TestCapitalize(t *testing.T) {
 	var tc = []pesticide.TestCase{
 		{Name: "TestEmpty", Input: `{{ "" | capitalize }}`, Expected: ""},
 		{Name: "CapitalizeAlreadyUpper", Input: `{{ "Foo Bar" | capitalize }}`, Expected: "Foo Bar"},
-		{Name: "CapitalizeWithSpace", Input: `{{ " Fe bar" | capitalize }}`, Expected: " Fe bar"},
+		{Name: "CapitalizeWithSpace", Input: `{{ " fe bar" | capitalize }}`, Expected: " Fe bar"},
 		{Name: "CapitalizeWithNumber", Input: `{{ "123boo_bar" | capitalize }}`, Expected: "123Boo_bar"},
 		{Name: "CapitalizeWithUnderscore", Input: `{{ "boo_bar" | capitalize }}`, Expected: "Boo_bar"},
 	}
@@ -440,7 +440,7 @@ func TestUncapitalize(t *testing.T) {
 	var tc = []pesticide.TestCase{
 		{Name: "TestEmpty", Input: `{{ "" | uncapitalize }}`, Expected: ""},
 		{Name: "UncapitalizeAlreadyLower", Input: `{{ "foo bar" | uncapitalize }}`, Expected: "foo bar"},
-		{Name: "UncapitalizeWithSpace", Input: `{{ " foo bar" | uncapitalize }}`, Expected: " foo bar"},
+		{Name: "UncapitalizeWithSpace", Input: `{{ " Foo bar" | uncapitalize }}`, Expected: " foo bar"},
 		{Name: "UncapitalizeWithNumber", Input: `{{ "123Boo_bar" | uncapitalize }}`, Expected: "123boo_bar"},
 		{Name: "UncapitalizeWithUnderscore", Input: `{{ "Boo_bar" | uncapitalize }}`, Expected: "boo_bar"},
 	}

--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -424,6 +424,30 @@ func TestSwapCase(t *testing.T) {
 	pesticide.RunTestCases(t, strings.NewRegistry(), tc)
 }
 
+func TestCapitalize(t *testing.T) {
+	var tc = []pesticide.TestCase{
+		{Name: "TestEmpty", Input: `{{ "" | capitalize }}`, Expected: ""},
+		{Name: "CapitalizeAlreadyUpper", Input: `{{ "Foo Bar" | capitalize }}`, Expected: "Foo Bar"},
+		{Name: "CapitalizeWithSpace", Input: `{{ " Fe bar" | capitalize }}`, Expected: " Fe bar"},
+		{Name: "CapitalizeWithNumber", Input: `{{ "123boo_bar" | capitalize }}`, Expected: "123Boo_bar"},
+		{Name: "CapitalizeWithUnderscore", Input: `{{ "boo_bar" | capitalize }}`, Expected: "Boo_bar"},
+	}
+
+	pesticide.RunTestCases(t, strings.NewRegistry(), tc)
+}
+
+func TestUncapitalize(t *testing.T) {
+	var tc = []pesticide.TestCase{
+		{Name: "TestEmpty", Input: `{{ "" | uncapitalize }}`, Expected: ""},
+		{Name: "UncapitalizeAlreadyLower", Input: `{{ "foo bar" | uncapitalize }}`, Expected: "foo bar"},
+		{Name: "UncapitalizeWithSpace", Input: `{{ " foo bar" | uncapitalize }}`, Expected: " foo bar"},
+		{Name: "UncapitalizeWithNumber", Input: `{{ "123Boo_bar" | uncapitalize }}`, Expected: "123boo_bar"},
+		{Name: "UncapitalizeWithUnderscore", Input: `{{ "Boo_bar" | uncapitalize }}`, Expected: "boo_bar"},
+	}
+
+	pesticide.RunTestCases(t, strings.NewRegistry(), tc)
+}
+
 func TestSplit(t *testing.T) {
 	var tc = []pesticide.TestCase{
 		{Name: "TestEmpty", Input: `{{ $v := ("" | split "-") }}{{$v._0}}`, Expected: ""},

--- a/registry/strings/strings.go
+++ b/registry/strings/strings.go
@@ -127,6 +127,8 @@ func (sr *StringsRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error 
 	sprout.AddFunction(funcsMap, "toTitleCase", sr.ToTitleCase)
 	sprout.AddFunction(funcsMap, "untitle", sr.Untitle)
 	sprout.AddFunction(funcsMap, "swapCase", sr.SwapCase)
+	sprout.AddFunction(funcsMap, "capitalize", sr.Capitalize)
+	sprout.AddFunction(funcsMap, "uncapitalize", sr.Uncapitalize)
 	sprout.AddFunction(funcsMap, "split", sr.Split)
 	sprout.AddFunction(funcsMap, "splitn", sr.Splitn)
 	sprout.AddFunction(funcsMap, "substr", sr.Substring)


### PR DESCRIPTION
## Description
When we manipulate strings in template, we need sometimes to capitalize or uncapitalize a string. A good example are when we manipulate go file and want to turn public/private functions.

## Changes
- Add `capitalize` functions on strings registry
- Add `uncapitalize` functions on strings registry

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.
