### PR TITLE
fix: capitalize with unicode and latin runes

### DIFF
--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -696,13 +696,7 @@ func (sr *StringsRegistry) SwapCase(str string) string {
 //
 //	{{ "hello world" | capitalize }} // Output: "Hello world"
 func (sr *StringsRegistry) Capitalize(str string) string {
-	for i, r := range str {
-		if unicode.IsLetter(r) {
-			return str[:i] + string(unicode.ToUpper(r)) + str[i+1:]
-		}
-	}
-
-	return str
+	return swapFirstLetter(str, cassingUpper)
 }
 
 // Uncapitalize converts the first letter of 'str' to lowercase.
@@ -719,13 +713,7 @@ func (sr *StringsRegistry) Capitalize(str string) string {
 //
 //	{{ "Hello World" | uncapitalize }} // Output: "hello World"
 func (sr *StringsRegistry) Uncapitalize(str string) string {
-	for i, r := range str {
-		if unicode.IsLetter(r) {
-			return str[:i] + string(unicode.ToLower(r)) + str[i+1:]
-		}
-	}
-
-	return str
+	return swapFirstLetter(str, cassingLower)
 }
 
 // Split divides 'orig' into a map of string parts using 'sep' as the separator.

--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -696,7 +696,7 @@ func (sr *StringsRegistry) SwapCase(str string) string {
 //
 //	{{ "hello world" | capitalize }} // Output: "Hello world"
 func (sr *StringsRegistry) Capitalize(str string) string {
-	return swapFirstLetter(str, cassingUpper)
+	return swapFirstLetter(str, true)
 }
 
 // Uncapitalize converts the first letter of 'str' to lowercase.
@@ -713,7 +713,7 @@ func (sr *StringsRegistry) Capitalize(str string) string {
 //
 //	{{ "Hello World" | uncapitalize }} // Output: "hello World"
 func (sr *StringsRegistry) Uncapitalize(str string) string {
-	return swapFirstLetter(str, cassingLower)
+	return swapFirstLetter(str, false)
 }
 
 // Split divides 'orig' into a map of string parts using 'sep' as the separator.

--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -446,6 +446,9 @@ func TestUncapitalize(t *testing.T) {
 		{Name: "UncapitalizeWithSpace", Input: `{{ " Foo bar" | uncapitalize }}`, Expected: " foo bar"},
 		{Name: "UncapitalizeWithNumber", Input: `{{ "123Boo_bar" | uncapitalize }}`, Expected: "123boo_bar"},
 		{Name: "UncapitalizeWithUnderscore", Input: `{{ "Boo_bar" | uncapitalize }}`, Expected: "boo_bar"},
+		{Name: "UncapitalizeWithEmoji", Input: `{{ "👍 Good" | uncapitalize }}`, Expected: "👍 good"},
+		{Name: "UncapitalizeWithUnicode", Input: `{{ "Été" | uncapitalize }}`, Expected: "été"},
+		{Name: "UncapitalizeWithArabic", Input: `{{ "مرحبا" | uncapitalize }}`, Expected: "مرحبا"},
 	}
 
 	pesticide.RunTestCases(t, strings.NewRegistry(), tc)

--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -431,6 +431,9 @@ func TestCapitalize(t *testing.T) {
 		{Name: "CapitalizeWithSpace", Input: `{{ " fe bar" | capitalize }}`, Expected: " Fe bar"},
 		{Name: "CapitalizeWithNumber", Input: `{{ "123boo_bar" | capitalize }}`, Expected: "123Boo_bar"},
 		{Name: "CapitalizeWithUnderscore", Input: `{{ "boo_bar" | capitalize }}`, Expected: "Boo_bar"},
+		{Name: "CapitalizeWithEmoji", Input: `{{ "👍 good" | capitalize }}`, Expected: "👍 Good"},
+		{Name: "CapitalizeWithUnicode", Input: `{{ "été" | capitalize }}`, Expected: "Été"},
+		{Name: "CapitalizeWithArabic", Input: `{{ "مرحبا" | capitalize }}`, Expected: "مرحبا"},
 	}
 
 	pesticide.RunTestCases(t, strings.NewRegistry(), tc)

--- a/registry/strings/helpers.go
+++ b/registry/strings/helpers.go
@@ -7,16 +7,6 @@ import (
 	"unicode/utf8"
 )
 
-// casingType represents the type of casingType to apply to a string.
-type casingType int
-
-const (
-	// cassingUpper casing represents the uppercase casing.
-	cassingUpper casingType = iota + 1
-	// cassingLower casing represents the lowercase casing.
-	cassingLower
-)
-
 // ellipsis truncates 'str' from both ends, preserving the middle part of
 // the string and appending ellipses to both ends if needed.
 //
@@ -289,7 +279,7 @@ func (sr *StringsRegistry) wordWrap(wrapLength int, newLineCharacter string, wra
 // Parameters:
 //
 //	str string - the string to modify.
-//	casing casingType - the casing to apply to the first letter.
+//	shouldUppercaseFirst bool - the casing to apply to the first letter.
 //
 // Returns:
 //
@@ -299,17 +289,18 @@ func (sr *StringsRegistry) wordWrap(wrapLength int, newLineCharacter string, wra
 //
 //	result := sr.swapFirstLetter("123hello", cassingUpper)
 //	fmt.Println(result) // Output: "123Hello"
-func swapFirstLetter(str string, casing casingType) string {
+func swapFirstLetter(str string, shouldUppercase bool) string {
 	var conditionFunc func(r rune) bool
 	var updateFunc func(r rune) rune
 
-	if casing == cassingUpper {
+	if shouldUppercase {
 		conditionFunc = unicode.IsUpper
 		updateFunc = unicode.ToUpper
 	} else {
 		conditionFunc = unicode.IsLower
 		updateFunc = unicode.ToLower
 	}
+
 	buf := []byte(str)
 	for i := 0; i < len(buf); {
 		r, size := utf8.DecodeRune(buf[i:])

--- a/registry/strings/helpers.go
+++ b/registry/strings/helpers.go
@@ -7,6 +7,16 @@ import (
 	"unicode/utf8"
 )
 
+// casingType represents the type of casingType to apply to a string.
+type casingType int
+
+const (
+	// cassingUpper casing represents the uppercase casing.
+	cassingUpper casingType = iota + 1
+	// cassingLower casing represents the lowercase casing.
+	cassingLower
+)
+
 // ellipsis truncates 'str' from both ends, preserving the middle part of
 // the string and appending ellipses to both ends if needed.
 //
@@ -271,4 +281,51 @@ func (sr *StringsRegistry) wordWrap(wrapLength int, newLineCharacter string, wra
 	}
 
 	return resultBuilder.String()
+}
+
+// swapFirstLetter swaps the first letter of the string 'str' to uppercase or
+// lowercase. The casing is determined by the 'casing' parameter.
+//
+// Parameters:
+//
+//	str string - the string to modify.
+//	casing casingType - the casing to apply to the first letter.
+//
+// Returns:
+//
+//	string - the modified string with the first letter in the desired casing.
+//
+// Example:
+//
+//	result := sr.swapFirstLetter("123hello", cassingUpper)
+//	fmt.Println(result) // Output: "123Hello"
+func swapFirstLetter(str string, casing casingType) string {
+	var conditionFunc func(r rune) bool
+	var updateFunc func(r rune) rune
+
+	if casing == cassingUpper {
+		conditionFunc = unicode.IsUpper
+		updateFunc = unicode.ToUpper
+	} else {
+		conditionFunc = unicode.IsLower
+		updateFunc = unicode.ToLower
+	}
+	buf := []byte(str)
+	for i := 0; i < len(buf); {
+		r, size := utf8.DecodeRune(buf[i:])
+
+		if unicode.IsLetter(r) {
+			if conditionFunc(r) {
+				return str
+			}
+
+			upperRune := updateFunc(r)
+			utf8.EncodeRune(buf[i:i+size], upperRune)
+
+			return string(buf)
+		}
+
+		i += size
+	}
+	return str
 }


### PR DESCRIPTION
## Description
`capitalize` and `uncapitalize` have untested statement with latin and unicode rune. Decode rune stored in multiple byte correctly.

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.

## Additional Information

Source of the report : https://github.com/go-sprout/sprout/pull/62#discussion_r1727405631 reported by @ccoVeille