### PR TITLE
docs: add functions signature in conventions

### DIFF
--- a/docs/introduction/templating-conventions.md
+++ b/docs/introduction/templating-conventions.md
@@ -31,6 +31,9 @@ description: >-
     Use `has` for functions that check for the existence or presence of something.
   * Follow the style guide for Idiomatic Naming Convention (e.g., [Initialisms](https://google.github.io/styleguide/go/decisions#initialisms))
 * **Function Comments:** For all exported functions and methods, provide comments describing their behavior, input parameters, and return values.
+* **Function Signature:** Functions should always adhere to the following rules:
+  * **Pipe Syntax:** Functions need to be designed to work with the pipe `|` syntax in the template engine.
+  * **Error Return:** Functions must have a dual output `(something, error)` to ensure proper error handling. Even when a function doesn't currently handle errors, the signature should still be `(something, error)` to allow for future error handling without causing breaking changes.
 
 #### Raw examples of registration names with function signatures
 


### PR DESCRIPTION
## Description
Functions signatures convention have not be write on the documentation, this pull request added it. 

## Changes
- Add convention about functions signatures

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.