### PR TITLE
chore: follow sprout conventions internally

### DIFF
--- a/docs/advanced/how-to-create-a-registry.md
+++ b/docs/advanced/how-to-create-a-registry.md
@@ -44,7 +44,7 @@ func NewRegistry() *OwnRegistry {
 
 // Uid provides a unique identifier for your registry.
 func (or *OwnRegistry) Uid() string {
-  return "organization.ownRegistry" // Ensure this identifier is unique and uses camelCase, prefixed by your handler separated with a dot. 
+  return "organization/repo.ownregistry" // Ensure this identifier is unique and uses lowercase, prefixed by your handler/repo separated with a dot. 
 }
 
 // LinkHandler connects the Handler to your registry, enabling runtime functionalities.

--- a/docs/advanced/how-to-create-a-registry.md
+++ b/docs/advanced/how-to-create-a-registry.md
@@ -2,11 +2,11 @@
 
 ## File Naming Conventions
 
-* `{{registry_name}}.go`: This file defines the registry, including key components like structs, interfaces, constants, and variables.
-* `functions.go`: Contains the implementation of exported functions, making them accessible to other developers.
-* `functions_test.go`: Includes tests for the exported functions to ensure they function as expected.
-* `helpers.go`: Contains internal helper functions that support the registry but are not exposed for public use.
-* `helpers_test.go`: Holds tests for the helper functions to validate their reliability.
+- `{{registry_name}}.go`: This file defines the registry, including key components like structs, interfaces, constants, and variables.
+- `functions.go`: Contains the implementation of exported functions, making them accessible to other developers.
+- `functions_test.go`: Includes tests for the exported functions to ensure they function as expected.
+- `helpers.go`: Contains internal helper functions that support the registry but are not exposed for public use.
+- `helpers_test.go`: Holds tests for the helper functions to validate their reliability.
 
 {% hint style="info" %}
 This structure ensures consistency and maintainability across different registries, making it easier for developers to contribute and collaborate effectively.\
@@ -42,9 +42,9 @@ func NewRegistry() *OwnRegistry {
   return &OwnRegistry{}
 }
 
-// Uid provides a unique identifier for your registry.
-func (or *OwnRegistry) Uid() string {
-  return "organization/repo.ownregistry" // Ensure this identifier is unique and uses lowercase, prefixed by your handler/repo separated with a dot. 
+// UID provides a unique identifier for your registry.
+func (or *OwnRegistry) UID() string {
+  return "organization/repo.ownregistry" // Ensure this identifier is unique and uses lowercase, prefixed by your handler/repo separated with a dot.
 }
 
 // LinkHandler connects the Handler to your registry, enabling runtime functionalities.

--- a/handler_test.go
+++ b/handler_test.go
@@ -22,7 +22,7 @@ type MockRegistry struct {
 
 var errMock = errors.New("mock error")
 
-func (m *MockRegistry) Uid() string {
+func (m *MockRegistry) UID() string {
 	args := m.Called()
 	return args.String(0)
 }
@@ -79,7 +79,7 @@ func TestDefaultHandler_Logger(t *testing.T) {
 func TestDefaultHandler_AddRegistries_Error(t *testing.T) {
 	mockRegistry := new(MockRegistry)
 	mockRegistry.linkHandlerMustCrash = true
-	mockRegistry.On("Uid").Return("mockRegistry")
+	mockRegistry.On("UID").Return("mockRegistry")
 	mockRegistry.On("LinkHandler", mock.Anything).Return(errMock)
 
 	dh := &DefaultHandler{
@@ -98,7 +98,7 @@ func TestDefaultHandler_AddRegistries_Error(t *testing.T) {
 func TestDefaultHandler_AddRegistry_Error_RegisterFuiesctions(t *testing.T) {
 	mockRegistry := new(MockRegistry)
 	mockRegistry.registerFuncsMustCrash = true
-	mockRegistry.On("Uid").Return("mockRegistry")
+	mockRegistry.On("UID").Return("mockRegistry")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return(errMock)
 
@@ -117,7 +117,7 @@ func TestDefaultHandler_AddRegistry_Error_RegisterFuiesctions(t *testing.T) {
 func TestDefaultHandler_AddRegistry_Error_RegisteriesAliases(t *testing.T) {
 	mockRegistry := new(MockRegistryWithAlias)
 	mockRegistry.registerAliasesMustCrash = true
-	mockRegistry.On("Uid").Return("mockRegistry")
+	mockRegistry.On("UID").Return("mockRegistry")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return()
 	mockRegistry.On("RegisterAliases", mock.Anything).Return(errMock)
@@ -139,7 +139,7 @@ func TestDefaultHandler_AddRegistry_Error_RegisteriesAliases(t *testing.T) {
 func TestDefaultHandler_AddRegistry_Error_RegisteriesNotices(t *testing.T) {
 	mockRegistry := new(MockRegistryWithNotices)
 	mockRegistry.registerNoticesMustCrash = true
-	mockRegistry.On("Uid").Return("mockRegistryWithNotices")
+	mockRegistry.On("UID").Return("mockRegistryWithNotices")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return()
 	mockRegistry.On("RegisterNotices", mock.Anything).Return()
@@ -163,7 +163,7 @@ func TestDefaultHandler_AddRegistry_Error_RegisteriesNotices(t *testing.T) {
 // TestDefaultHandler_AddRegistry tests the AddRegistry method of DefaultHandler.
 func TestDefaultHandler_AddRegistry(t *testing.T) {
 	mockRegistry := new(MockRegistry)
-	mockRegistry.On("Uid").Return("mockRegistry")
+	mockRegistry.On("UID").Return("mockRegistry")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return()
 
@@ -184,12 +184,12 @@ func TestDefaultHandler_AddRegistry(t *testing.T) {
 // TestDefaultHandler_AddRegistries tests the AddRegistries method of DefaultHandler.
 func TestDefaultHandler_AddRegistries(t *testing.T) {
 	mockRegistry1 := new(MockRegistry)
-	mockRegistry1.On("Uid").Return("mockRegistry1")
+	mockRegistry1.On("UID").Return("mockRegistry1")
 	mockRegistry1.On("LinkHandler", mock.Anything).Return()
 	mockRegistry1.On("RegisterFunctions", mock.Anything).Return()
 
 	mockRegistry2 := new(MockRegistry)
-	mockRegistry2.On("Uid").Return("mockRegistry2")
+	mockRegistry2.On("UID").Return("mockRegistry2")
 	mockRegistry2.On("LinkHandler", mock.Anything).Return()
 	mockRegistry2.On("RegisterFunctions", mock.Anything).Return()
 
@@ -213,7 +213,7 @@ func TestDefaultHandler_AddRegistries(t *testing.T) {
 // TestDefaultHandler_AddRegistryWithAlias tests AddRegistry when the registry also implements RegistryWithAlias.
 func TestDefaultHandler_AddRegistryWithAlias(t *testing.T) {
 	mockRegistry := new(MockRegistryWithAlias)
-	mockRegistry.On("Uid").Return("mockRegistryWithAlias")
+	mockRegistry.On("UID").Return("mockRegistryWithAlias")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return()
 	mockRegistry.On("RegisterAliases", mock.Anything).Return()
@@ -236,7 +236,7 @@ func TestDefaultHandler_AddRegistryWithAlias(t *testing.T) {
 
 func TestDefaultHandler_AddRegistryWithNotices(t *testing.T) {
 	mockRegistry := new(MockRegistryWithNotices)
-	mockRegistry.On("Uid").Return("mockRegistryWithNotices")
+	mockRegistry.On("UID").Return("mockRegistryWithNotices")
 	mockRegistry.On("LinkHandler", mock.Anything).Return()
 	mockRegistry.On("RegisterFunctions", mock.Anything).Return()
 	mockRegistry.On("RegisterNotices", mock.Anything).Return()

--- a/registry.go
+++ b/registry.go
@@ -15,8 +15,7 @@ type FunctionMap = template.FuncMap
 // It also allows for easy extension of the template functions by adding a new one.
 type Registry interface {
 	// Uid returns the unique name of the registry. This name is used to identify
-	// the registry and in future prevent duplicate registry registration.
-	// TODO: Consider implement a solution for duplicate registry registration.
+	// the registry author and name and prevent duplicate registry registration.
 	Uid() string
 	// LinkHandler links the given Handler to the registry.
 	// * This method help you to have access to the main handler and its

--- a/registry.go
+++ b/registry.go
@@ -14,9 +14,9 @@ type FunctionMap = template.FuncMap
 // performance of the template engine.
 // It also allows for easy extension of the template functions by adding a new one.
 type Registry interface {
-	// Uid returns the unique name of the registry. This name is used to identify
+	// UID returns the unique name of the registry. This name is used to identify
 	// the registry author and name and prevent duplicate registry registration.
-	Uid() string
+	UID() string
 	// LinkHandler links the given Handler to the registry.
 	// * This method help you to have access to the main handler and its
 	// * functionalities, like the logger, error handling, and more.

--- a/registry/_example/_example.go
+++ b/registry/_example/_example.go
@@ -15,7 +15,7 @@ func NewRegistry() *ExampleRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (or *ExampleRegistry) Uid() string {
-	return "example" // ! Must be unique and in camel case
+	return "go-sprout/sprout.exampleofregistry" // ! Must be unique and in lowercase, replace `exampleofregistry` with your registry name and `go-sprout/sprout` with your handle name
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/_example/_example.go
+++ b/registry/_example/_example.go
@@ -13,8 +13,8 @@ func NewRegistry() *ExampleRegistry {
 	return &ExampleRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (or *ExampleRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (or *ExampleRegistry) UID() string {
 	return "go-sprout/sprout.exampleofregistry" // ! Must be unique and in lowercase, replace `exampleofregistry` with your registry name and `go-sprout/sprout` with your handle name
 }
 

--- a/registry/backward/backward.go
+++ b/registry/backward/backward.go
@@ -34,8 +34,8 @@ func NewRegistry() *BackwardCompatibilityRegistry {
 	return &BackwardCompatibilityRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (bcr *BackwardCompatibilityRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (bcr *BackwardCompatibilityRegistry) UID() string {
 	return "go-sprout/sprout.backwardcompatibilitywithsprig"
 }
 

--- a/registry/backward/backward.go
+++ b/registry/backward/backward.go
@@ -36,7 +36,7 @@ func NewRegistry() *BackwardCompatibilityRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (bcr *BackwardCompatibilityRegistry) Uid() string {
-	return "backwardCompatibilityWithSprig" // ! Must be unique and in camel case
+	return "go-sprout/sprout.backwardcompatibilitywithsprig"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/checksum/checksum.go
+++ b/registry/checksum/checksum.go
@@ -13,7 +13,7 @@ func NewRegistry() *ChecksumRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (cr *ChecksumRegistry) Uid() string {
-	return "checksum"
+	return "go-sprout/sprout.checksum"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/checksum/checksum.go
+++ b/registry/checksum/checksum.go
@@ -11,8 +11,8 @@ func NewRegistry() *ChecksumRegistry {
 	return &ChecksumRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (cr *ChecksumRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (cr *ChecksumRegistry) UID() string {
 	return "go-sprout/sprout.checksum"
 }
 

--- a/registry/conversion/conversion.go
+++ b/registry/conversion/conversion.go
@@ -13,7 +13,7 @@ func NewRegistry() *ConversionRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (or *ConversionRegistry) Uid() string {
-	return "conversion"
+	return "go-sprout/sprout.conversion"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/conversion/conversion.go
+++ b/registry/conversion/conversion.go
@@ -11,8 +11,8 @@ func NewRegistry() *ConversionRegistry {
 	return &ConversionRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (or *ConversionRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (or *ConversionRegistry) UID() string {
 	return "go-sprout/sprout.conversion"
 }
 

--- a/registry/crypto/crypto.go
+++ b/registry/crypto/crypto.go
@@ -58,7 +58,7 @@ func NewRegistry() *CryptoRegistry {
 
 // Uid returns the unique identifier of the crypto handler.
 func (ch *CryptoRegistry) Uid() string {
-	return "crypto"
+	return "go-sprout/sprout.crypto"
 }
 
 func (ch *CryptoRegistry) LinkHandler(fh sprout.Handler) error {

--- a/registry/crypto/crypto.go
+++ b/registry/crypto/crypto.go
@@ -56,8 +56,8 @@ func NewRegistry() *CryptoRegistry {
 	return &CryptoRegistry{}
 }
 
-// Uid returns the unique identifier of the crypto handler.
-func (ch *CryptoRegistry) Uid() string {
+// UID returns the unique identifier of the crypto handler.
+func (ch *CryptoRegistry) UID() string {
 	return "go-sprout/sprout.crypto"
 }
 

--- a/registry/encoding/encoding.go
+++ b/registry/encoding/encoding.go
@@ -11,8 +11,8 @@ func NewRegistry() *EncodingRegistry {
 	return &EncodingRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (or *EncodingRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (or *EncodingRegistry) UID() string {
 	return "go-sprout/sprout.encoding"
 }
 

--- a/registry/encoding/encoding.go
+++ b/registry/encoding/encoding.go
@@ -13,7 +13,7 @@ func NewRegistry() *EncodingRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (or *EncodingRegistry) Uid() string {
-	return "encoding"
+	return "go-sprout/sprout.encoding"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/env/env.go
+++ b/registry/env/env.go
@@ -11,8 +11,8 @@ func NewRegistry() *EnvironmentRegistry {
 	return &EnvironmentRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (or *EnvironmentRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (or *EnvironmentRegistry) UID() string {
 	return "go-sprout/sprout.env"
 }
 

--- a/registry/env/env.go
+++ b/registry/env/env.go
@@ -13,7 +13,7 @@ func NewRegistry() *EnvironmentRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (or *EnvironmentRegistry) Uid() string {
-	return "env"
+	return "go-sprout/sprout.env"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/filesystem/filesystem.go
+++ b/registry/filesystem/filesystem.go
@@ -13,7 +13,7 @@ func NewRegistry() *FileSystemRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (fsr *FileSystemRegistry) Uid() string {
-	return "filesystem"
+	return "go-sprout/sprout.filesystem"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/filesystem/filesystem.go
+++ b/registry/filesystem/filesystem.go
@@ -11,8 +11,8 @@ func NewRegistry() *FileSystemRegistry {
 	return &FileSystemRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (fsr *FileSystemRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (fsr *FileSystemRegistry) UID() string {
 	return "go-sprout/sprout.filesystem"
 }
 

--- a/registry/maps/maps.go
+++ b/registry/maps/maps.go
@@ -13,7 +13,7 @@ func NewRegistry() *MapsRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (mr *MapsRegistry) Uid() string {
-	return "maps"
+	return "go-sprout/sprout.maps"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/maps/maps.go
+++ b/registry/maps/maps.go
@@ -11,8 +11,8 @@ func NewRegistry() *MapsRegistry {
 	return &MapsRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (mr *MapsRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (mr *MapsRegistry) UID() string {
 	return "go-sprout/sprout.maps"
 }
 

--- a/registry/network/network.go
+++ b/registry/network/network.go
@@ -13,8 +13,8 @@ func NewRegistry() *NetworkRegistry {
 	return &NetworkRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (nr *NetworkRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (nr *NetworkRegistry) UID() string {
 	return "go-sprout/sprout.network"
 }
 

--- a/registry/network/network.go
+++ b/registry/network/network.go
@@ -15,7 +15,7 @@ func NewRegistry() *NetworkRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (nr *NetworkRegistry) Uid() string {
-	return "network" // ! Must be unique and in camel case
+	return "go-sprout/sprout.network"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/numeric/numeric.go
+++ b/registry/numeric/numeric.go
@@ -25,8 +25,8 @@ func NewRegistry() *NumericRegistry {
 	return &NumericRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (nr *NumericRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (nr *NumericRegistry) UID() string {
 	return "go-sprout/sprout.numeric"
 }
 

--- a/registry/numeric/numeric.go
+++ b/registry/numeric/numeric.go
@@ -27,7 +27,7 @@ func NewRegistry() *NumericRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (nr *NumericRegistry) Uid() string {
-	return "numeric"
+	return "go-sprout/sprout.numeric"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/random/random.go
+++ b/registry/random/random.go
@@ -44,7 +44,7 @@ func NewRegistry() *RandomRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (rr *RandomRegistry) Uid() string {
-	return "random"
+	return "go-sprout/sprout.random"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/random/random.go
+++ b/registry/random/random.go
@@ -42,8 +42,8 @@ func NewRegistry() *RandomRegistry {
 	return &RandomRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (rr *RandomRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (rr *RandomRegistry) UID() string {
 	return "go-sprout/sprout.random"
 }
 

--- a/registry/reflect/reflect.go
+++ b/registry/reflect/reflect.go
@@ -11,8 +11,8 @@ func NewRegistry() *ReflectRegistry {
 	return &ReflectRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (rr *ReflectRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (rr *ReflectRegistry) UID() string {
 	return "go-sprout/sprout.reflect"
 }
 

--- a/registry/reflect/reflect.go
+++ b/registry/reflect/reflect.go
@@ -13,7 +13,7 @@ func NewRegistry() *ReflectRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (rr *ReflectRegistry) Uid() string {
-	return "reflect"
+	return "go-sprout/sprout.reflect"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/regexp/regexp.go
+++ b/registry/regexp/regexp.go
@@ -13,7 +13,7 @@ func NewRegistry() *RegexpRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (rr *RegexpRegistry) Uid() string {
-	return "regexp"
+	return "go-sprout/sprout.regexp"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/regexp/regexp.go
+++ b/registry/regexp/regexp.go
@@ -11,8 +11,8 @@ func NewRegistry() *RegexpRegistry {
 	return &RegexpRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (rr *RegexpRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (rr *RegexpRegistry) UID() string {
 	return "go-sprout/sprout.regexp"
 }
 

--- a/registry/semver/semver.go
+++ b/registry/semver/semver.go
@@ -13,7 +13,7 @@ func NewRegistry() *SemverRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (sr *SemverRegistry) Uid() string {
-	return "semver"
+	return "go-sprout/sprout.semver"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/semver/semver.go
+++ b/registry/semver/semver.go
@@ -11,8 +11,8 @@ func NewRegistry() *SemverRegistry {
 	return &SemverRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (sr *SemverRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (sr *SemverRegistry) UID() string {
 	return "go-sprout/sprout.semver"
 }
 

--- a/registry/slices/slices.go
+++ b/registry/slices/slices.go
@@ -13,7 +13,7 @@ func NewRegistry() *SlicesRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (sr *SlicesRegistry) Uid() string {
-	return "slices"
+	return "go-sprout/sprout.slices"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/slices/slices.go
+++ b/registry/slices/slices.go
@@ -11,8 +11,8 @@ func NewRegistry() *SlicesRegistry {
 	return &SlicesRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (sr *SlicesRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (sr *SlicesRegistry) UID() string {
 	return "go-sprout/sprout.slices"
 }
 

--- a/registry/std/std.go
+++ b/registry/std/std.go
@@ -13,7 +13,7 @@ func NewRegistry() *StdRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (sr *StdRegistry) Uid() string {
-	return "std"
+	return "go-sprout/sprout.std"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/std/std.go
+++ b/registry/std/std.go
@@ -11,8 +11,8 @@ func NewRegistry() *StdRegistry {
 	return &StdRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (sr *StdRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (sr *StdRegistry) UID() string {
 	return "go-sprout/sprout.std"
 }
 

--- a/registry/strings/strings.go
+++ b/registry/strings/strings.go
@@ -81,8 +81,8 @@ func NewRegistry() *StringsRegistry {
 	return &StringsRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (sr *StringsRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (sr *StringsRegistry) UID() string {
 	return "go-sprout/sprout.strings"
 }
 

--- a/registry/strings/strings.go
+++ b/registry/strings/strings.go
@@ -83,7 +83,7 @@ func NewRegistry() *StringsRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (sr *StringsRegistry) Uid() string {
-	return "strings"
+	return "go-sprout/sprout.strings"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/time/time.go
+++ b/registry/time/time.go
@@ -11,8 +11,8 @@ func NewRegistry() *TimeRegistry {
 	return &TimeRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (tr *TimeRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (tr *TimeRegistry) UID() string {
 	return "go-sprout/sprout.time"
 }
 

--- a/registry/time/time.go
+++ b/registry/time/time.go
@@ -13,7 +13,7 @@ func NewRegistry() *TimeRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (tr *TimeRegistry) Uid() string {
-	return "time"
+	return "go-sprout/sprout.time"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/uniqueid/uniqueid.go
+++ b/registry/uniqueid/uniqueid.go
@@ -13,7 +13,7 @@ func NewRegistry() *UniqueIDRegistry {
 
 // Uid returns the unique identifier of the registry.
 func (ur *UniqueIDRegistry) Uid() string {
-	return "uniqueid"
+	return "go-sprout/sprout.uniqueid"
 }
 
 // LinkHandler links the handler to the registry at runtime.

--- a/registry/uniqueid/uniqueid.go
+++ b/registry/uniqueid/uniqueid.go
@@ -11,8 +11,8 @@ func NewRegistry() *UniqueIDRegistry {
 	return &UniqueIDRegistry{}
 }
 
-// Uid returns the unique identifier of the registry.
-func (ur *UniqueIDRegistry) Uid() string {
+// UID returns the unique identifier of the registry.
+func (ur *UniqueIDRegistry) UID() string {
 	return "go-sprout/sprout.uniqueid"
 }
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -58,13 +58,13 @@ func TestAddAlias(t *testing.T) {
 func TestWithRegistries(t *testing.T) {
 	// Define two registries with functions and aliases
 	mockRegistry1 := new(MockRegistry)
-	mockRegistry1.On("Uid").Return("mockRegistry1")
+	mockRegistry1.On("UID").Return("mockRegistry1")
 	mockRegistry1.On("LinkHandler", mock.Anything).Return(nil)
 	mockRegistry1.On("RegisterFunctions", mock.Anything).Return(nil)
 
 	mockRegistry2 := new(MockRegistry)
 	mockRegistry2.linkHandlerMustCrash = true
-	mockRegistry2.On("Uid").Return("mockRegistry2")
+	mockRegistry2.On("UID").Return("mockRegistry2")
 	mockRegistry2.On("LinkHandler", mock.Anything).Return(nil)
 	mockRegistry1.On("RegisterFunctions", mock.Anything).Return(nil)
 

--- a/sprigin/sprig_backward_compatibility_test.go
+++ b/sprigin/sprig_backward_compatibility_test.go
@@ -64,9 +64,23 @@ func TestSprigHandler(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t, registriesUids, []string{
-		"std", "uniqueid", "semver", "backwardCompatibilityWithSprig",
-		"reflect", "time", "strings", "random", "checksum", "conversion",
-		"numeric", "encoding", "regexp", "slices", "maps", "crypto",
-		"filesystem", "env",
+		"go-sprout/sprout.std",
+		"go-sprout/sprout.uniqueid",
+		"go-sprout/sprout.semver",
+		"go-sprout/sprout.backwardcompatibilitywithsprig",
+		"go-sprout/sprout.reflect",
+		"go-sprout/sprout.time",
+		"go-sprout/sprout.strings",
+		"go-sprout/sprout.random",
+		"go-sprout/sprout.checksum",
+		"go-sprout/sprout.conversion",
+		"go-sprout/sprout.numeric",
+		"go-sprout/sprout.encoding",
+		"go-sprout/sprout.regexp",
+		"go-sprout/sprout.slices",
+		"go-sprout/sprout.maps",
+		"go-sprout/sprout.crypto",
+		"go-sprout/sprout.filesystem",
+		"go-sprout/sprout.env",
 	})
 }

--- a/sprigin/sprig_backward_compatibility_test.go
+++ b/sprigin/sprig_backward_compatibility_test.go
@@ -58,12 +58,12 @@ func TestSprigHandler(t *testing.T) {
 
 	assert.Len(t, handler.registries, 18) // Hardcoded for backward compatibility
 
-	registriesUids := []string{}
+	registriesUIDs := []string{}
 	for _, registry := range handler.registries {
-		registriesUids = append(registriesUids, registry.Uid())
+		registriesUIDs = append(registriesUIDs, registry.UID())
 	}
 
-	assert.ElementsMatch(t, registriesUids, []string{
+	assert.ElementsMatch(t, registriesUIDs, []string{
 		"go-sprout/sprout.std",
 		"go-sprout/sprout.uniqueid",
 		"go-sprout/sprout.semver",


### PR DESCRIPTION
## Description
In documentation we ask to have a clear Uid definition but we don't follow this rule inside the sprout package.

## Changes
- Add the organization and repo name in all package UID
- Turn UID un lowercase (to help future implementation)

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.