### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/groups/all.md
+++ b/docs/groups/all.md
@@ -16,20 +16,20 @@ import "github.com/go-sprout/sprout/group/all"
 
 ### List of registries
 
-* [**checksum**](checksum.md): Tools to generate and verify checksums for data integrity.
-* [**conversion**](conversion.md): Functions to convert between different data types within templates.
-* [**encoding**](encoding.md): Methods for encoding and decoding data in various formats.
-* [**env**](env.md): Access and manipulate environment variables within templates.
-* [**filesystem**](filesystem.md): Functions for interacting with the file system.
-* [**maps**](maps.md): Tools to manipulate and interact with map data structures.
-* [**network**](network.md): Functions to interact with network resources.
-* [**numeric**](numeric.md): Utilities for numerical operations and calculations.
-* [**random**](random.md): Functions to generate random numbers, strings, and other data.
-* [**reflect**](reflect.md): Tools to inspect and manipulate data types using reflection.
-* [**regexp**](regexp.md): Regular expression functions for pattern matching and string manipulation.
-* [**semver**](semver.md): Functions to handle semantic versioning and comparison.
-* [**slices**](slices.md): Utilities for slice operations, including filtering, sorting, and transforming.
-* [**std**](std.md): Standard functions for common operations.
-* [**strings**](strings.md): Functions for string manipulation, including formatting, splitting, and joining.
-* [**time**](time.md): Tools to handle dates, times, and time-related calculations.
-* [**uniqueid**](uniqueid.md): Functions to generate unique identifiers, such as UUIDs.
+* [**checksum**](../registries/checksum.md): Tools to generate and verify checksums for data integrity.
+* [**conversion**](../registries/conversion.md): Functions to convert between different data types within templates.
+* [**encoding**](../registries/encoding.md): Methods for encoding and decoding data in various formats.
+* [**env**](../registries/env.md): Access and manipulate environment variables within templates.
+* [**filesystem**](../registries/filesystem.md): Functions for interacting with the file system.
+* [**maps**](../registries/maps.md): Tools to manipulate and interact with map data structures.
+* [**network**](../registries/network.md): Functions to interact with network resources.
+* [**numeric**](../registries/numeric.md): Utilities for numerical operations and calculations.
+* [**random**](../registries/random.md): Functions to generate random numbers, strings, and other data.
+* [**reflect**](../registries/reflect.md): Tools to inspect and manipulate data types using reflection.
+* [**regexp**](../registries/regexp.md): Regular expression functions for pattern matching and string manipulation.
+* [**semver**](../registries/semver.md): Functions to handle semantic versioning and comparison.
+* [**slices**](../registries/slices.md): Utilities for slice operations, including filtering, sorting, and transforming.
+* [**std**](../registries/std.md): Standard functions for common operations.
+* [**strings**](../registries/strings.md): Functions for string manipulation, including formatting, splitting, and joining.
+* [**time**](../registries/time.md): Tools to handle dates, times, and time-related calculations.
+* [**uniqueid**](../registries/uniqueid.md): Functions to generate unique identifiers, such as UUIDs.

--- a/docs/groups/hermetic.md
+++ b/docs/groups/hermetic.md
@@ -17,17 +17,17 @@ import "github.com/go-sprout/sprout/group/hermetic"
 
 ### List of registries
 
-* [**checksum**](checksum.md): Tools to generate and verify checksums for data integrity.
-* [**conversion**](conversion.md): Functions to convert between different data types within templates.
-* [**encoding**](encoding.md): Methods for encoding and decoding data in various formats.
-* [**filesystem**](filesystem.md): Functions for interacting with the file system.
-* [**maps**](maps.md): Tools to manipulate and interact with map data structures.
-* [**numeric**](numeric.md): Utilities for numerical operations and calculations.
-* [**reflect**](reflect.md): Tools to inspect and manipulate data types using reflection.
-* [**regexp**](regexp.md): Regular expression functions for pattern matching and string manipulation.
-* [**semver**](semver.md): Functions to handle semantic versioning and comparison.
-* [**slices**](slices.md): Utilities for slice operations, including filtering, sorting, and transforming.
-* [**std**](std.md): Standard functions for common operations.
-* [**strings**](strings.md): Functions for string manipulation, including formatting, splitting, and joining.
-* [**time**](time.md): Tools to handle dates, times, and time-related calculations.
-* [**uniqueid**](uniqueid.md): Functions to generate unique identifiers, such as UUIDs.
+* [**checksum**](../registries/checksum.md): Tools to generate and verify checksums for data integrity.
+* [**conversion**](../registries/conversion.md): Functions to convert between different data types within templates.
+* [**encoding**](../registries/encoding.md): Methods for encoding and decoding data in various formats.
+* [**filesystem**](../registries/filesystem.md): Functions for interacting with the file system.
+* [**maps**](../registries/maps.md): Tools to manipulate and interact with map data structures.
+* [**numeric**](../registries/numeric.md): Utilities for numerical operations and calculations.
+* [**reflect**](../registries/reflect.md): Tools to inspect and manipulate data types using reflection.
+* [**regexp**](../registries/regexp.md): Regular expression functions for pattern matching and string manipulation.
+* [**semver**](../registries/semver.md): Functions to handle semantic versioning and comparison.
+* [**slices**](../registries/slices.md): Utilities for slice operations, including filtering, sorting, and transforming.
+* [**std**](../registries/std.md): Standard functions for common operations.
+* [**strings**](../registries/strings.md): Functions for string manipulation, including formatting, splitting, and joining.
+* [**time**](../registries/time.md): Tools to handle dates, times, and time-related calculations.
+* [**uniqueid**](../registries/uniqueid.md): Functions to generate unique identifiers, such as UUIDs.

--- a/docs/roadmap-to-sprout-v1.0.md
+++ b/docs/roadmap-to-sprout-v1.0.md
@@ -85,8 +85,9 @@ When you are a middle-app (between sprout and the user how write the template), 
 The solution are to embed a notice system in the template library to warn the end-user of a deprecation and let x versions between the deprecation notice and the replacement / removal of the function.
 
 {% hint style="success" %}
-These features are implemented on v0.6.0, documentation can be found here :\
-[broken-reference](broken-reference/ "mention")
+These features are implemented on v0.6.0, documentation can be found here:
+
+[function-notices.md](features/function-notices.md "mention")
 {% endhint %}
 
 ## Compatibility between spring and sprout


### PR DESCRIPTION
## Description
The documentation contains some broken links. This PR updates the links so that they point to the correct files.

## Changes
* Fix links to registries in _All_ and _Hermetic_ groups.
* Fix link to _Function Notices_ in _Roadmap to Sprout v1.0_.

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~ All tests behaved exactly the same as before.
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~This change requires a change to the documentation on the website.~~
