### PR TITLE
feat: new uniqueid functions (uuid)

### DIFF
--- a/docs/registries/uniqueid.md
+++ b/docs/registries/uniqueid.md
@@ -30,3 +30,133 @@ Uuidv4 generates a new random UUID (Universally Unique Identifier) version 4.
 {% endtab %}
 {% endtabs %}
 
+### <mark style="color:purple;">uuidv7</mark>
+
+Uuidv7 generates a new UUID version 7, based on the current Unix time in milliseconds. Unlike a version 4, successive UUIDs are sortable by generation time.
+
+<table data-header-hidden><thead><tr><th width="174">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">Uuidv7() (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ uuidv7 }} // Output(will be different): 018f5395-4e88-7c2a-9f3b-1d7e4a6c8b90
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+Prefer `uuidv7` over `uuidv4` when the identifiers are used as database keys, the time ordering keeps the index locality that a fully random UUID destroys.
+{% endhint %}
+
+### <mark style="color:purple;">uuidv5</mark>
+
+Uuidv5 generates a UUID version 5, derived from a namespace and a name using SHA-1. The same namespace and name always produce the same UUID.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">Uuidv5(namespace string, name string) (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "python.org" | uuidv5 "dns" }} // Output: 886313e1-3b8a-5372-9b90-0c9aee199e5d
+{{ "python.org" | uuidv5 "6ba7b810-9dad-11d1-80b4-00c04fd430c8" }} // Output: 886313e1-3b8a-5372-9b90-0c9aee199e5d
+{{ "python.org" | uuidv5 "invalid" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+The namespace is either one of the predefined names `dns`, `url`, `oid`, `x500` (case insensitive), or any valid UUID to use a namespace of your own.
+{% endhint %}
+
+### <mark style="color:purple;">uuidv3</mark>
+
+Uuidv3 generates a UUID version 3, derived from a namespace and a name using MD5. The same namespace and name always produce the same UUID.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">Uuidv3(namespace string, name string) (string, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "python.org" | uuidv3 "dns" }} // Output: 6fa459ea-ee8a-3ca4-894e-db77e160355e
+{{ "python.org" | uuidv3 "invalid" }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+Prefer `uuidv5` for new usages, the version 3 only exists for compatibility with systems already relying on MD5 derived UUIDs.
+{% endhint %}
+
+### <mark style="color:purple;">uuidNil</mark>
+
+UuidNil returns the nil UUID, the UUID with all its bits set to zero.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">UuidNil() string
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ uuidNil }} // Output: 00000000-0000-0000-0000-000000000000
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">isUUID</mark>
+
+IsUUID checks if the given value is a valid UUID.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">IsUUID(value string) bool
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "886313e1-3b8a-5372-9b90-0c9aee199e5d" | isUUID }} // Output: true
+{{ "urn:uuid:886313e1-3b8a-5372-9b90-0c9aee199e5d" | isUUID }} // Output: true
+{{ "886313e13b8a53729b900c9aee199e5d" | isUUID }} // Output: true
+{{ "not-a-uuid" | isUUID }} // Output: false
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+On top of the canonical form, three alternative forms are accepted: the urn prefixed one (`urn:uuid:886313e1-…`), the braced one (`{886313e1-…}`) and the one without hyphen (`886313e13b8a…`). Use `uuidVersion` if you also need to validate which version you received.
+{% endhint %}
+
+### <mark style="color:purple;">uuidVersion</mark>
+
+UuidVersion returns the version of the given UUID.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">UuidVersion(value string) (int, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ "886313e1-3b8a-5372-9b90-0c9aee199e5d" | uuidVersion }} // Output: 5
+{{ "not-a-uuid" | uuidVersion }} // Error
+```
+{% endtab %}
+{% endtabs %}
+
+### <mark style="color:purple;">uuidTime</mark>
+
+UuidTime returns the time embedded in the given UUID. Only the versions carrying a timestamp are supported, namely the versions 1, 2, 6 and 7.
+
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">UuidTime(value string) (time.Time, error)
+</code></pre></td></tr></tbody></table>
+
+{% tabs %}
+{% tab title="Template Example" %}
+```go
+{{ dateInZone "2006-01-02 15:04:05" ("018f5395-4e88-7000-8000-000000000000" | uuidTime) "UTC" }} // Output: 2024-05-07 15:04:05
+{{ "886313e1-3b8a-5372-9b90-0c9aee199e5d" | uuidTime }} // Error
+{{ "not-a-uuid" | uuidTime }} // Error
+```
+{% endtab %}
+{% endtabs %}
+

--- a/registry/uniqueid/functions.go
+++ b/registry/uniqueid/functions.go
@@ -1,6 +1,9 @@
 package uniqueid
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/google/uuid"
 )
 
@@ -17,4 +20,161 @@ import (
 // [Sprout Documentation: uuidv4]: https://docs.atom.codes/sprout/registries/uniqueid#uuidv4
 func (ur *UniqueIDRegistry) Uuidv4() string {
 	return uuid.New().String()
+}
+
+// Uuidv7 generates a new UUID (Universally Unique Identifier) version 7, based
+// on the current Unix time in milliseconds. Unlike a version 4, successive
+// UUIDs are sortable by generation time.
+//
+// Returns:
+//
+//	string - a new UUID string.
+//	error - when the random source cannot be read.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidv7].
+//
+// [Sprout Documentation: uuidv7]: https://docs.atom.codes/sprout/registries/uniqueid#uuidv7
+func (ur *UniqueIDRegistry) Uuidv7() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
+// Uuidv5 generates a UUID (Universally Unique Identifier) version 5, derived
+// from a namespace and a name using SHA-1. The same namespace and name always
+// produce the same UUID.
+//
+// Parameters:
+//
+//	namespace string - one of the predefined namespaces (dns, url, oid, x500) or any valid UUID.
+//	name string - the name to derive the UUID from.
+//
+// Returns:
+//
+//	string - the UUID string derived from the namespace and the name.
+//	error - when the namespace is neither a predefined one nor a valid UUID.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidv5].
+//
+// [Sprout Documentation: uuidv5]: https://docs.atom.codes/sprout/registries/uniqueid#uuidv5
+func (ur *UniqueIDRegistry) Uuidv5(namespace string, name string) (string, error) {
+	ns, err := computeNamespace(namespace)
+	if err != nil {
+		return "", err
+	}
+	return uuid.NewSHA1(ns, []byte(name)).String(), nil
+}
+
+// Uuidv3 generates a UUID (Universally Unique Identifier) version 3, derived
+// from a namespace and a name using MD5. The same namespace and name always
+// produce the same UUID.
+//
+// Prefer `uuidv5` for new usages, version 3 only exists for compatibility with
+// systems already relying on MD5 derived UUIDs.
+//
+// Parameters:
+//
+//	namespace string - one of the predefined namespaces (dns, url, oid, x500) or any valid UUID.
+//	name string - the name to derive the UUID from.
+//
+// Returns:
+//
+//	string - the UUID string derived from the namespace and the name.
+//	error - when the namespace is neither a predefined one nor a valid UUID.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidv3].
+//
+// [Sprout Documentation: uuidv3]: https://docs.atom.codes/sprout/registries/uniqueid#uuidv3
+func (ur *UniqueIDRegistry) Uuidv3(namespace string, name string) (string, error) {
+	ns, err := computeNamespace(namespace)
+	if err != nil {
+		return "", err
+	}
+	return uuid.NewMD5(ns, []byte(name)).String(), nil
+}
+
+// UuidNil returns the nil UUID, the UUID with all its bits set to zero.
+//
+// Returns:
+//
+//	string - the nil UUID string.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidNil].
+//
+// [Sprout Documentation: uuidNil]: https://docs.atom.codes/sprout/registries/uniqueid#uuidnil
+func (ur *UniqueIDRegistry) UuidNil() string {
+	return uuid.Nil.String()
+}
+
+// IsUUID checks if the given value is a valid UUID. On top of the canonical
+// form, the urn prefixed form, the braced form and the form without hyphen are
+// accepted.
+//
+// Parameters:
+//
+//	value string - the value to check.
+//
+// Returns:
+//
+//	bool - true if the value is a valid UUID, otherwise false.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: isUUID].
+//
+// [Sprout Documentation: isUUID]: https://docs.atom.codes/sprout/registries/uniqueid#isuuid
+func (ur *UniqueIDRegistry) IsUUID(value string) bool {
+	return uuid.Validate(value) == nil
+}
+
+// UuidVersion returns the version of the given UUID.
+//
+// Parameters:
+//
+//	value string - the UUID to read the version from.
+//
+// Returns:
+//
+//	int - the version of the UUID.
+//	error - when the value is not a valid UUID.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidVersion].
+//
+// [Sprout Documentation: uuidVersion]: https://docs.atom.codes/sprout/registries/uniqueid#uuidversion
+func (ur *UniqueIDRegistry) UuidVersion(value string) (int, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return 0, err
+	}
+	return int(id.Version()), nil
+}
+
+// UuidTime returns the time embedded in the given UUID. Only the versions
+// carrying a timestamp are supported, namely the versions 1, 2, 6 and 7.
+//
+// Parameters:
+//
+//	value string - the UUID to read the time from.
+//
+// Returns:
+//
+//	time.Time - the time at which the UUID was generated.
+//	error - when the value is not a valid UUID or when its version carries no timestamp.
+//
+// For an example of this function in a Go template, refer to [Sprout Documentation: uuidTime].
+//
+// [Sprout Documentation: uuidTime]: https://docs.atom.codes/sprout/registries/uniqueid#uuidtime
+func (ur *UniqueIDRegistry) UuidTime(value string) (time.Time, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	switch id.Version() {
+	case 1, 2, 6, 7:
+		sec, nsec := id.Time().UnixTime()
+		return time.Unix(sec, nsec), nil
+	default:
+		return time.Time{}, fmt.Errorf("uuid version %d does not embed a time", id.Version())
+	}
 }

--- a/registry/uniqueid/functions_test.go
+++ b/registry/uniqueid/functions_test.go
@@ -1,10 +1,26 @@
 package uniqueid_test
 
 import (
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-sprout/sprout/pesticide"
 	"github.com/go-sprout/sprout/registry/uniqueid"
+)
+
+const (
+	// uuidv7Fixture is a version 7 UUID generated at 2024-05-07T15:04:05Z, with
+	// every random bit set to zero to keep it deterministic.
+	uuidv7Fixture = "018f5395-4e88-7000-8000-000000000000"
+	// uuidv1Fixture is a version 1 UUID generated at 2024-05-07T15:04:05Z, with
+	// every random bit set to zero to keep it deterministic.
+	uuidv1Fixture = "0bcce080-0c83-11ef-8000-000000000000"
+	// uuidv5Fixture is the UUID of the name "python.org" in the dns namespace.
+	uuidv5Fixture = "886313e1-3b8a-5372-9b90-0c9aee199e5d"
 )
 
 func TestUuidv4(t *testing.T) {
@@ -13,4 +29,147 @@ func TestUuidv4(t *testing.T) {
 	}
 
 	pesticide.RunRegexpTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidv7(t *testing.T) {
+	tc := []pesticide.RegexpTestCase{
+		{Name: "TestUuidv7", Template: `{{uuidv7}}`, Regexp: `^[\da-f]{8}-[\da-f]{4}-7[\da-f]{3}-[\da-f]{4}-[\da-f]{12}$`, Length: 36},
+	}
+
+	pesticide.RunRegexpTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+// TestUuidv7IsSortable ensures the defining property of the version 7: two
+// UUIDs generated in a row are ordered by generation time.
+func TestUuidv7IsSortable(t *testing.T) {
+	first, err := pesticide.TestTemplate(t, uniqueid.NewRegistry(), `{{ uuidv7 }}`, nil)
+	require.NoError(t, err)
+
+	second, err := pesticide.TestTemplate(t, uniqueid.NewRegistry(), `{{ uuidv7 }}`, nil)
+	require.NoError(t, err)
+
+	require.Less(t, first, second)
+}
+
+// failingReader is a random source always failing, used to check the error of
+// the generators is propagated instead of being swallowed.
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("no entropy available")
+}
+
+func TestUuidv7WithoutEntropy(t *testing.T) {
+	uuid.SetRand(failingReader{})
+	t.Cleanup(func() { uuid.SetRand(nil) })
+
+	tc := []pesticide.TestCase{
+		{Name: "TestUuidv7WithoutEntropy", Input: `{{ uuidv7 }}`, ExpectedErr: "no entropy available"},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidv5(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestPredefinedNamespace", Input: `{{ "python.org" | uuidv5 "dns" }}`, ExpectedOutput: uuidv5Fixture},
+		{Name: "TestPredefinedNamespaceUppercase", Input: `{{ "python.org" | uuidv5 "DNS" }}`, ExpectedOutput: uuidv5Fixture},
+		{Name: "TestUrlNamespace", Input: `{{ "python.org" | uuidv5 "url" }}`, ExpectedOutput: "7af94e2b-4dd9-50f0-9c9a-8a48519bdef0"},
+		{Name: "TestOidNamespace", Input: `{{ "python.org" | uuidv5 "oid" }}`, ExpectedOutput: "cd5d0bff-2444-5d26-ab53-4f7db1cb733d"},
+		{Name: "TestX500Namespace", Input: `{{ "python.org" | uuidv5 "x500" }}`, ExpectedOutput: "e9246a06-296f-5b50-be57-0519806c97e8"},
+		{Name: "TestCustomNamespace", Input: `{{ "python.org" | uuidv5 "6ba7b810-9dad-11d1-80b4-00c04fd430c8" }}`, ExpectedOutput: uuidv5Fixture},
+		{Name: "TestEmptyName", Input: `{{ "" | uuidv5 "dns" }}`, ExpectedOutput: "4ebd0208-8328-5d69-8c44-ec50939c0967"},
+		{Name: "TestIsDeterministic", Input: `{{ eq ("python.org" | uuidv5 "dns") ("python.org" | uuidv5 "dns") }}`, ExpectedOutput: "true"},
+		{Name: "TestNamesAreDistinct", Input: `{{ ne ("python.org" | uuidv5 "dns") ("golang.org" | uuidv5 "dns") }}`, ExpectedOutput: "true"},
+		{Name: "TestNamespacesAreDistinct", Input: `{{ ne ("python.org" | uuidv5 "dns") ("python.org" | uuidv5 "url") }}`, ExpectedOutput: "true"},
+		{Name: "TestWithInvalidNamespace", Input: `{{ "python.org" | uuidv5 "invalid" }}`, ExpectedErr: `invalid namespace "invalid"`},
+		{Name: "TestWithEmptyNamespace", Input: `{{ "python.org" | uuidv5 "" }}`, ExpectedErr: `invalid namespace ""`},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidv3(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestPredefinedNamespace", Input: `{{ "python.org" | uuidv3 "dns" }}`, ExpectedOutput: "6fa459ea-ee8a-3ca4-894e-db77e160355e"},
+		{Name: "TestCustomNamespace", Input: `{{ "python.org" | uuidv3 "6ba7b810-9dad-11d1-80b4-00c04fd430c8" }}`, ExpectedOutput: "6fa459ea-ee8a-3ca4-894e-db77e160355e"},
+		{Name: "TestEmptyName", Input: `{{ "" | uuidv3 "dns" }}`, ExpectedOutput: "c87ee674-4ddc-3efe-a74e-dfe25da5d7b3"},
+		{Name: "TestIsDeterministic", Input: `{{ eq ("python.org" | uuidv3 "dns") ("python.org" | uuidv3 "dns") }}`, ExpectedOutput: "true"},
+		{Name: "TestDiffersFromVersion5", Input: `{{ ne ("python.org" | uuidv3 "dns") ("python.org" | uuidv5 "dns") }}`, ExpectedOutput: "true"},
+		{Name: "TestWithInvalidNamespace", Input: `{{ "python.org" | uuidv3 "invalid" }}`, ExpectedErr: `invalid namespace "invalid"`},
+		{Name: "TestWithEmptyNamespace", Input: `{{ "python.org" | uuidv3 "" }}`, ExpectedErr: `invalid namespace ""`},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidNil(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestUuidNil", Input: `{{ uuidNil }}`, ExpectedOutput: "00000000-0000-0000-0000-000000000000"},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestIsUUID(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestValidUUID", Input: `{{ "886313e1-3b8a-5372-9b90-0c9aee199e5d" | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestValidNilUUID", Input: `{{ uuidNil | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestValidGeneratedUUID", Input: `{{ uuidv4 | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestUppercaseUUID", Input: `{{ "886313E1-3B8A-5372-9B90-0C9AEE199E5D" | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestUrnPrefixedUUID", Input: `{{ "urn:uuid:886313e1-3b8a-5372-9b90-0c9aee199e5d" | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestBracedUUID", Input: `{{ "{886313e1-3b8a-5372-9b90-0c9aee199e5d}" | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestUUIDWithoutHyphen", Input: `{{ "886313e13b8a53729b900c9aee199e5d" | isUUID }}`, ExpectedOutput: "true"},
+		{Name: "TestInvalidUUID", Input: `{{ "not-a-uuid" | isUUID }}`, ExpectedOutput: "false"},
+		{Name: "TestEmptyString", Input: `{{ "" | isUUID }}`, ExpectedOutput: "false"},
+		{Name: "TestTruncatedUUID", Input: `{{ "886313e1-3b8a-5372-9b90" | isUUID }}`, ExpectedOutput: "false"},
+		{Name: "TestInvalidUrnPrefix", Input: `{{ "urn:uuiE:886313e1-3b8a-5372-9b90-0c9aee199e5d" | isUUID }}`, ExpectedOutput: "false"},
+		{Name: "TestUnbalancedBraces", Input: `{{ "{886313e1-3b8a-5372-9b90-0c9aee199e5d[" | isUUID }}`, ExpectedOutput: "false"},
+		{Name: "TestNonHexCharacters", Input: `{{ "zzzzzzzz-3b8a-5372-9b90-0c9aee199e5d" | isUUID }}`, ExpectedOutput: "false"},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidVersion(t *testing.T) {
+	tc := []pesticide.TestCase{
+		{Name: "TestVersion5", Input: `{{ .V | uuidVersion }}`, ExpectedOutput: "5", Data: map[string]any{"V": uuidv5Fixture}},
+		{Name: "TestVersion7", Input: `{{ .V | uuidVersion }}`, ExpectedOutput: "7", Data: map[string]any{"V": uuidv7Fixture}},
+		{Name: "TestVersion1", Input: `{{ .V | uuidVersion }}`, ExpectedOutput: "1", Data: map[string]any{"V": uuidv1Fixture}},
+		{Name: "TestVersion4", Input: `{{ uuidv4 | uuidVersion }}`, ExpectedOutput: "4"},
+		{Name: "TestUrnPrefixedUUID", Input: `{{ "urn:uuid:886313e1-3b8a-5372-9b90-0c9aee199e5d" | uuidVersion }}`, ExpectedOutput: "5"},
+		{Name: "TestNilUUID", Input: `{{ uuidNil | uuidVersion }}`, ExpectedOutput: "0"},
+		{Name: "TestEmptyString", Input: `{{ "" | uuidVersion }}`, ExpectedErr: "invalid UUID"},
+		{Name: "TestWithInvalidInput", Input: `{{ "not-a-uuid" | uuidVersion }}`, ExpectedErr: "invalid UUID"},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+func TestUuidTime(t *testing.T) {
+	// temporarily force time.Local to UTC to keep the output deterministic
+	pesticide.ForceTimeLocal(t, time.UTC)
+
+	tc := []pesticide.TestCase{
+		{Name: "TestVersion7", Input: `{{ .V | uuidTime }}`, ExpectedOutput: "2024-05-07 15:04:05 +0000 UTC", Data: map[string]any{"V": uuidv7Fixture}},
+		{Name: "TestVersion1", Input: `{{ .V | uuidTime }}`, ExpectedOutput: "2024-05-07 15:04:05 +0000 UTC", Data: map[string]any{"V": uuidv1Fixture}},
+		{Name: "TestVersion4HasNoTime", Input: `{{ uuidv4 | uuidTime }}`, ExpectedErr: "uuid version 4 does not embed a time"},
+		{Name: "TestVersion5HasNoTime", Input: `{{ .V | uuidTime }}`, ExpectedErr: "uuid version 5 does not embed a time", Data: map[string]any{"V": uuidv5Fixture}},
+		{Name: "TestNilUUIDHasNoTime", Input: `{{ uuidNil | uuidTime }}`, ExpectedErr: "uuid version 0 does not embed a time"},
+		{Name: "TestWithInvalidInput", Input: `{{ "not-a-uuid" | uuidTime }}`, ExpectedErr: "invalid UUID"},
+	}
+
+	pesticide.RunTestCases(t, uniqueid.NewRegistry(), tc)
+}
+
+// TestUuidTimeOnVersion6 covers the version 6, which cannot be pinned to a
+// fixture: the version bits overwrite the low bits of its timestamp, so a
+// hand-written fixture would assert that quirk instead of our own code.
+func TestUuidTimeOnVersion6(t *testing.T) {
+	id, err := uuid.NewV6()
+	require.NoError(t, err)
+
+	got, err := uniqueid.NewRegistry().UuidTime(id.String())
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), got, time.Minute)
 }

--- a/registry/uniqueid/helpers.go
+++ b/registry/uniqueid/helpers.go
@@ -1,0 +1,32 @@
+package uniqueid
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// predefinedNamespaces maps the well-known namespace names defined by RFC 9562
+// to their UUID, to let templates use `dns` instead of the raw UUID.
+var predefinedNamespaces = map[string]uuid.UUID{
+	"dns":  uuid.NameSpaceDNS,
+	"url":  uuid.NameSpaceURL,
+	"oid":  uuid.NameSpaceOID,
+	"x500": uuid.NameSpaceX500,
+}
+
+// computeNamespace returns the UUID of the given namespace. The namespace can
+// either be one of the predefined names (dns, url, oid, x500) or any valid UUID
+// to use a custom namespace.
+func computeNamespace(namespace string) (uuid.UUID, error) {
+	if ns, ok := predefinedNamespaces[strings.ToLower(namespace)]; ok {
+		return ns, nil
+	}
+
+	ns, err := uuid.Parse(namespace)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid namespace %q: must be one of dns, url, oid, x500 or a valid UUID", namespace)
+	}
+	return ns, nil
+}

--- a/registry/uniqueid/uniqueid.go
+++ b/registry/uniqueid/uniqueid.go
@@ -25,5 +25,12 @@ func (ur *UniqueIDRegistry) LinkHandler(fh sprout.Handler) error {
 // RegisterFunctions registers all functions of the registry.
 func (ur *UniqueIDRegistry) RegisterFunctions(funcsMap sprout.FunctionMap) error {
 	sprout.AddFunction(funcsMap, "uuidv4", ur.Uuidv4)
+	sprout.AddFunction(funcsMap, "uuidv7", ur.Uuidv7)
+	sprout.AddFunction(funcsMap, "uuidv5", ur.Uuidv5)
+	sprout.AddFunction(funcsMap, "uuidv3", ur.Uuidv3)
+	sprout.AddFunction(funcsMap, "uuidNil", ur.UuidNil)
+	sprout.AddFunction(funcsMap, "isUUID", ur.IsUUID)
+	sprout.AddFunction(funcsMap, "uuidVersion", ur.UuidVersion)
+	sprout.AddFunction(funcsMap, "uuidTime", ur.UuidTime)
 	return nil
 }


### PR DESCRIPTION
## Description

The `uniqueid` registry only had `uuidv4`. Issue #155 asks for more unique id generators and utils around uuid. This PR covers the **UUID scope only**: version 7, the deterministic versions 5 and 3, and the accessors the issue refers to as "utils around uuid".

## Changes

Seven functions added to the `uniqueid` registry:

| Function | Signature | Notes |
| --- | --- | --- |
| `uuidv7` | `Uuidv7() (string, error)` | time-ordered, successive ids sort by generation time |
| `uuidv5` | `Uuidv5(namespace string, name string) (string, error)` | deterministic, SHA-1 based |
| `uuidv3` | `Uuidv3(namespace string, name string) (string, error)` | deterministic, MD5 based, legacy |
| `uuidNil` | `UuidNil() string` | the all-zero UUID |
| `isUUID` | `IsUUID(value string) bool` | |
| `uuidVersion` | `UuidVersion(value string) (int, error)` | |
| `uuidTime` | `UuidTime(value string) (time.Time, error)` | versions 1, 2, 6 and 7 |

## Fixes #155

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [x] This change requires a change to the documentation on the website.