### PR TITLE
docs: typo corrections on migration guide

### DIFF
--- a/docs/migration-from-sprig.md
+++ b/docs/migration-from-sprig.md
@@ -37,7 +37,7 @@ List the registries needed for your project and register them with the handler. 
 * **Sprout:** Functions are managed by a handler, allowing for better control over function availability, error handling, and logging.
 
 {% hint style="success" %}
-**Migration Top**
+**Migration Tip**
 
 Nothing to do, using the new handler is enough.
 {% endhint %}
@@ -50,7 +50,7 @@ Nothing to do, using the new handler is enough.
 {% hint style="success" %}
 **Migration Tip**
 
-You can learn mote about the safe strategy here: [safe-functions.md](features/safe-functions.md "mention")
+You can learn more about the safe strategy here: [safe-functions.md](features/safe-functions.md "mention")
 {% endhint %}
 
 ### 4. **Function Aliases**


### PR DESCRIPTION
## Description
Correction for two small typos spotted in the [**Migration from Sprig**](https://docs.atom.codes/sprout/migration-from-sprig) documentation.

## Changes
Well, the typos were corrected 🤷 

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x]  My code follows the code style of this project.
- [ ]  I have added tests to cover my changes. **(not relevant)**
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly. **(not relevant)**
- [x] This change requires a change to the documentation on the website.
