### PR TITLE
fix(sprigin): respect the hermetic disclosure for aliasing and new sprout functions

### DIFF
--- a/sprigin/hermetic_test.go
+++ b/sprigin/hermetic_test.go
@@ -1,0 +1,56 @@
+package sprigin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-sprout/sprout"
+	"github.com/go-sprout/sprout/registry/env"
+	"github.com/go-sprout/sprout/registry/random"
+)
+
+// registryFunctionNames returns the template names registered by a registry.
+func registryFunctionNames(t *testing.T, registry sprout.Registry) []string {
+	t.Helper()
+
+	funcs := sprout.FunctionMap{}
+	require.NoError(t, registry.RegisterFunctions(funcs))
+
+	names := make([]string, 0, len(funcs))
+	for name := range funcs {
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestHermeticFuncMapExcludesNonDeterministicFunctions guards the hermetic func
+// maps against a gap that already happened once: nonhermeticFunctions was
+// written against the sprig names, so `expandEnv` stayed reachable while its
+// `expandenv` alias was filtered out. Deriving the expectation from the
+// registries makes any new env or random function fail here until it is
+// classified.
+func TestHermeticFuncMapExcludesNonDeterministicFunctions(t *testing.T) {
+	hermetic := HermeticTxtFuncMap()
+
+	t.Run("no function of the env and random registries", func(t *testing.T) {
+		for _, registry := range []sprout.Registry{env.NewRegistry(), random.NewRegistry()} {
+			for _, name := range registryFunctionNames(t, registry) {
+				assert.NotContains(t, hermetic, name, "`%s` reaches the environment or the random source", name)
+			}
+		}
+	})
+
+	t.Run("no clock or randomness dependent function", func(t *testing.T) {
+		for _, name := range []string{"now", "date", "dateAgo", "dateInZone", "htmlDate", "htmlDateInZone", "uuidv4", "uuidv7", "getHostByName"} {
+			assert.NotContains(t, hermetic, name, "`%s` does not evaluate to the same result for a given input", name)
+		}
+	})
+
+	t.Run("deterministic functions are kept", func(t *testing.T) {
+		for _, name := range []string{"uuidv5", "uuidv3", "uuidNil", "isUUID", "uuidVersion", "toLocalDate", "fromUnix", "trim", "toJSON"} {
+			assert.Contains(t, hermetic, name, "`%s` is deterministic and must stay available", name)
+		}
+	})
+}

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -76,10 +76,16 @@ var bc_registerSprigFuncs = sprout.FunctionAliasMap{
 
 // These functions are not guaranteed to evaluate to the same result for given input, because they
 // refer to the environment or global state.
+//
+// The list must cover every function of the `env` and `random` registries, plus
+// the clock and randomness dependent ones of `time` and `uniqueid`. It is
+// asserted by TestHermeticFuncMapExcludesNonDeterministicFunctions, so a new
+// function in those registries fails the tests until it is classified here.
 // FOR BACKWARDS COMPATIBILITY ONLY
 var nonhermeticFunctions = []string{
 	// Date functions
 	"date",
+	"dateAgo",
 	"dateInZone",
 	"dateModify",
 	"now",
@@ -92,11 +98,14 @@ var nonhermeticFunctions = []string{
 	"randAscii",
 	"randNumeric",
 	"randBytes",
+	"randInt",
 	"uuidv4",
+	"uuidv7",
 
 	// OS
 	"env",
 	"expandenv",
+	"expandEnv",
 
 	// Network
 	"getHostByName",


### PR DESCRIPTION
## Description
New functions and alias added in v1.1.0 are not added to hermetic map in sprigin package.

## Changes
- Add new functions (uuidv7, dateAgo) to hermetic map
- Add expandEnv alias to hermetic map

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.