### PR TITLE
fix: divint by zero are possible due to casting

### DIFF
--- a/registry/numeric/functions.go
+++ b/registry/numeric/functions.go
@@ -1,6 +1,7 @@
 package numeric
 
 import (
+	"errors"
 	"math"
 	"reflect"
 
@@ -198,11 +199,20 @@ func (nr *NumericRegistry) Mulf(values ...any) (any, error) {
 // Returns:
 //
 //	int64 - the quotient of the division.
+//	error - when a divisor is zero, or when a value cannot be converted to a number.
 //
 // For an example of this function in a Go template, refer to [Sprout Documentation: div].
 //
 // [Sprout Documentation: div]: https://docs.atom.codes/sprout/registries/numeric#div
 func (nr *NumericRegistry) DivInt(values ...any) (int64, error) {
+	if len(values) > 1 {
+		for _, divisor := range values[1:] {
+			if value, err := cast.ToFloat64E(divisor); err == nil && value == 0 {
+				return 0, errors.New("cannot divide by zero")
+			}
+		}
+	}
+
 	result, err := nr.Divf(values...)
 	if err != nil {
 		return 0, err

--- a/registry/numeric/functions_test.go
+++ b/registry/numeric/functions_test.go
@@ -163,6 +163,10 @@ func TestDivInt(t *testing.T) {
 		{Input: `{{ div 1.1 2.2 }}`, ExpectedOutput: "0"},
 		{Input: `{{ 4 | div 5 }}`, ExpectedOutput: "1"},
 		{Input: `{{ div 1 "a" }}`, ExpectedErr: "failed to convert: a to float64"},
+		{Name: "TestDivideByZero", Input: `{{ div 1 0 }}`, ExpectedErr: "cannot divide by zero"},
+		{Name: "TestDivideByZeroInChain", Input: `{{ div 100 5 0 }}`, ExpectedErr: "cannot divide by zero"},
+		{Name: "TestZeroDividend", Input: `{{ div 0 5 }}`, ExpectedOutput: "0"},
+		{Name: "TestWithoutArgument", Input: `{{ div }}`, ExpectedOutput: "0"},
 	}
 
 	pesticide.RunTestCases(t, numeric.NewRegistry(), tc)


### PR DESCRIPTION
## Description
Due to a cast cascade, the division by zero are possible when use for example this template `{{divint 100 2 0}}` 

## Changes
- Add a guard clause to ensure no division by zero are triggered

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This change requires a change to the documentation on the website.