### PR TITLE
fix(strings): make shuffle safe for concurrent use

### DIFF
--- a/registry/strings/functions.go
+++ b/registry/strings/functions.go
@@ -297,7 +297,7 @@ func (sr *StringsRegistry) Trunc(count int, value string) string {
 // [Sprout Documentation: shuffle]: https://docs.atom.codes/sprout/registries/strings#shuffle
 func (sr *StringsRegistry) Shuffle(value string) string {
 	runes := []rune(value)
-	mathrand.New(randSource).Shuffle(len(runes), func(i, j int) {
+	mathrand.Shuffle(len(runes), func(i, j int) {
 		runes[i], runes[j] = runes[j], runes[i]
 	})
 	return string(runes)

--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -1,6 +1,7 @@
 package strings_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/go-sprout/sprout/pesticide"
@@ -172,6 +173,20 @@ func TestShuffle(t *testing.T) {
 	}
 
 	pesticide.RunRegexpTestCases(t, strings.NewRegistry(), tc)
+}
+
+func TestShuffleConcurrent(t *testing.T) {
+	registry := strings.NewRegistry()
+
+	var group sync.WaitGroup
+	for range 32 {
+		group.Go(func() {
+			for range 1_000 {
+				registry.Shuffle("concurrent template rendering")
+			}
+		})
+	}
+	group.Wait()
 }
 
 func TestEllipsis(t *testing.T) {

--- a/registry/strings/strings.go
+++ b/registry/strings/strings.go
@@ -1,13 +1,6 @@
 package strings
 
-import (
-	cryptorand "crypto/rand"
-	"math/big"
-	mathrand "math/rand"
-	"time"
-
-	"github.com/go-sprout/sprout"
-)
+import "github.com/go-sprout/sprout"
 
 // caseStyle defines the rules for transforming strings based on capitalization,
 // separator insertion, and case enforcement. This struct is typically used to
@@ -48,11 +41,6 @@ type caseStyle struct {
 	ForceUppercase  bool // Whether to force all characters to uppercase.
 }
 
-// randSource is a global variable that provides a source of randomness seeded with
-// a cryptographically secure random number. This source is used throughout various
-// random generation functions to ensure that randomness is both fast and non-repetitive.
-var randSource mathrand.Source
-
 var (
 	camelCaseStyle    = caseStyle{Separator: -1, CapitalizeNext: true, CapitalizeFirst: false, ForceLowercase: true}
 	kebabCaseStyle    = caseStyle{Separator: '-', ForceLowercase: true}
@@ -62,15 +50,6 @@ var (
 	pathCaseStyle     = caseStyle{Separator: '/', ForceLowercase: true}
 	constantCaseStyle = caseStyle{Separator: '_', ForceUppercase: true}
 )
-
-// init is an initialization function that seeds the global random source used
-// in random string generation. It retrieves a secure timestamp-based seed from
-// crypto/rand and uses it to initialize math/rand's source, ensuring that random
-// values are not predictable across program restarts.
-func init() {
-	index, _ := cryptorand.Int(cryptorand.Reader, big.NewInt(time.Now().UnixNano()))
-	randSource = mathrand.NewSource(index.Int64())
-}
 
 type StringsRegistry struct {
 	handler sprout.Handler // Embedding Handler for shared functionality


### PR DESCRIPTION
## Description

  Fixes a data race when shuffle is invoked concurrently, including through safeShuffle.

  ## Changes

  - Replaced the package-global, non-concurrency-safe math/rand.Source with the concurrency-safe package-level math/rand.Shuffle.
  - Removed the now-unused random-source initialization.
  - Added a concurrent Shuffle regression test.

  ## Fixes

  #195

  ## Checklist

  - [x] I have read the CONTRIBUTING.md document.
  - [x] My code follows the code style of this project.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have updated the documentation accordingly.
  - [ ] This change requires a change to the documentation on the website.

  ## Additional Information

  go test -race ./registry/strings -run 'TestShuffle|TestShuffleConcurrent' -count=1 and go test ./registry/strings pass. The full suite is
  blocked by this environment’s DNS failure in unrelated hostname-resolution tests.