### PR TITLE
fix(sprigin): empty derivePassword

### DIFF
--- a/docs/registries/crypto.md
+++ b/docs/registries/crypto.md
@@ -65,7 +65,7 @@ Be careful, this method uses the default cost of the library and can cause secur
 
 The function derives a password based on the provided counter, password type, password, user, and site, generating a consistent and secure password using these inputs.
 
-<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">DerivePassword(counter uint32, passwordType, password, user, site string) (string, error)
+<table data-header-hidden><thead><tr><th width="164">Name</th><th>Value</th></tr></thead><tbody><tr><td>Signature</td><td><pre class="language-go"><code class="lang-go">DerivePassword(counter int, passwordType, password, user, site string) (string, error)
 </code></pre></td></tr></tbody></table>
 
 {% tabs %}

--- a/registry/crypto/functions.go
+++ b/registry/crypto/functions.go
@@ -74,7 +74,7 @@ func (ch *CryptoRegistry) Htpasswd(username string, password string) (string, er
 // For an example of this function in a Go template, refer to [Sprout Documentation: derivePassword].
 //
 // [Sprout Documentation: derivePassword]: https://docs.atom.codes/sprout/registries/crypto#derivepassword
-func (ch *CryptoRegistry) DerivePassword(counter uint32, passwordType, password, user, site string) (string, error) {
+func (ch *CryptoRegistry) DerivePassword(counter int, passwordType, password, user, site string) (string, error) {
 	templates := passwordTypeTemplates[passwordType]
 	if templates == nil {
 		return "", fmt.Errorf("cannot find password template %s", passwordType)
@@ -94,7 +94,7 @@ func (ch *CryptoRegistry) DerivePassword(counter uint32, passwordType, password,
 	buffer.Truncate(len(masterPasswordSeed))
 	_ = binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
 	buffer.WriteString(site)
-	_ = binary.Write(&buffer, binary.BigEndian, counter)
+	_ = binary.Write(&buffer, binary.BigEndian, uint32(counter))
 
 	hmacv := hmac.New(sha256.New, key)
 	hmacv.Write(buffer.Bytes())

--- a/sprigin/compatibility/compatibility.tmpl
+++ b/sprigin/compatibility/compatibility.tmpl
@@ -2175,17 +2175,16 @@
 [CODE_001812]    {{ "-----BEGIN DSA PRIVATE KEY-----\nMIIBugIB...FIXED_DSA_KEY...==\n-----END DSA PRIVATE KEY-----" }}
 [CODE_001813]    {{ "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEE...FIXED_ECDSA_KEY...=\n-----END EC PRIVATE KEY-----" }}
 
-{{/* derivePassword is not available in sprigin - using fixed values */}}
-[CODE_001814]    {{ "ZedaFaxcZaso9*" }}
-[CODE_001815]    {{ "OyfAD1rm3ja7H$kqKI9*" }}
-[CODE_001816]    {{ "TukMop5(" }}
-[CODE_001817]    {{ "Par4" }}
-[CODE_001818]    {{ "Fovi2@JifpTupx" }}
-[CODE_001819]    {{ "1359" }}
-[CODE_001820]    {{ "cannot find password template name" }}
-[CODE_001821]    {{ "cannot find password template phrase" }}
-[CODE_001822]    {{ "Cari7[JayuGugi" }}
-[CODE_001823]    {{ "otj83XfJ" }}
+[CODE_001814]    {{ derivePassword 1 "long" "password" "user" "example.com" }}
+[CODE_001815]    {{ derivePassword 1 "maximum" "password" "user" "example.com" }}
+[CODE_001816]    {{ derivePassword 1 "medium" "password" "user" "example.com" }}
+[CODE_001817]    {{ derivePassword 1 "basic" "password" "user" "example.com" }}
+[CODE_001818]    {{ derivePassword 1 "pin" "password" "user" "example.com" }}
+[CODE_001819]    {{ derivePassword 2 "long" "password" "user" "example.com" }}
+[CODE_001820]    {{/* FIXME: derivePassword 1 "name" "password" "user" "example.com" */}}
+[CODE_001821]    {{/* FIXME: derivePassword 1 "phrase" "password" "user" "example.com" */}}
+[CODE_001822]    {{ derivePassword 1 "long" "" "" "" }}
+[CODE_001823]    {{ derivePassword 2 "maximum" "" "" "" }}
 
 {{/* ============================================== */}}
 {{/* CRYPTO FUNCTIONS - AES (NON-DETERMINISTIC IV)  */}}

--- a/sprigin/sprig_backward_compatibility.go
+++ b/sprigin/sprig_backward_compatibility.go
@@ -297,6 +297,7 @@ func (sh *SprigHandler) Build() sprout.FunctionMap {
 		if !strings.HasPrefix(funcName, "must") {
 			sh.funcsMap[funcName] = func(args ...any) (any, error) {
 				out, _ := runtime.SafeCall(fn, args...)
+				// TODO: match sprig's error handling
 				return out, nil
 			}
 		}


### PR DESCRIPTION
## Description

Calling `derivePassword` from sprigin leads to the following error:

```log
cannot safecall function: recovered from a panic: reflect: Call using int as type uint32
```

Which is ignored by the `runtime.SafeCall` wrapper and unknown to the user. The error itself is also caused partially by the wrapper, which is declared with `args ...any` parameters, so text/template assumes the literal integers have type `int` instead of 'uint32'.

Another issue related to this is that `derivePassword` could not be called with non-literal integers, because they would default to `int` in the same way. Even for sprout functions.

Declaring derivePassword with `counter int` should solve both cases.

## Changes

- Make `derivePassword` accept `int`.
- Add compatibility tests for `derivePassword` (partial).
- Add a TODO note for the `runtime.SafeCall` wrapper. I'll take a look at it later, if no one does it first, and then finish the `derivePassword` compat tests.

## Fixes #157

## Checklist
- [X] I have read the **CONTRIBUTING.md** document.
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation accordingly.
- [X] This change requires a change to the documentation on the website.

## Additional Information
<!-- Any additional information regarding this pull request. -->
