### PR TITLE
fix(strings): count the ellipsis offset in runes, not bytes

### DIFF
--- a/registry/strings/functions_test.go
+++ b/registry/strings/functions_test.go
@@ -206,6 +206,8 @@ func TestEllipsisBoth(t *testing.T) {
 		{Name: "TestShort", Input: `{{ "foo" | ellipsisBoth 5 4 }}`, ExpectedOutput: "foo"},
 		{Name: "TestTruncate", Input: `{{ "foooboooooo" | ellipsisBoth 4 9 }}`, ExpectedOutput: "...boo..."},
 		{Name: "TestZeroTruncate", Input: `{{ "foobar" | ellipsisBoth 0 0 }}`, ExpectedOutput: "foobar"},
+		{Name: "TestMultiByteOffset", Input: `{{ "héllo" | ellipsisBoth 2 10 }}`, ExpectedOutput: "llo"},
+		{Name: "TestOffsetPastEnd", Input: `{{ "foo" | ellipsisBoth 5 10 }}`, ExpectedOutput: ""},
 	}
 
 	pesticide.RunTestCases(t, strings.NewRegistry(), tc)

--- a/registry/strings/helpers.go
+++ b/registry/strings/helpers.go
@@ -31,7 +31,12 @@ func (sr *StringsRegistry) ellipsis(value string, offset int, maxWidth int) stri
 
 	// If the string doesn't need trimming, return it as is.
 	if runeCount <= maxWidth || runeCount <= offset {
-		return value[offset:]
+		if offset == 0 {
+			return value
+		}
+
+		runes := []rune(value)
+		return string(runes[min(offset, len(runes)):])
 	}
 
 	// Determine end position for the substring, ensuring room for the ellipsis.

--- a/registry/strings/helpers_test.go
+++ b/registry/strings/helpers_test.go
@@ -500,6 +500,8 @@ func TestEllipsis(t *testing.T) {
 		{name: "truncate_end", value: "hello world", offset: 0, maxWidth: 8, expected: "hello..."},
 		{name: "maxWidth_too_small", value: "hello", offset: 0, maxWidth: 3, expected: "hello"},
 		{name: "with_offset", value: "hello world", offset: 2, maxWidth: 10, expected: "...llo ..."},
+		{name: "offset_inside_multibyte_rune", value: "héllo", offset: 2, maxWidth: 10, expected: "llo"},
+		{name: "offset_past_end", value: "foo", offset: 5, maxWidth: 10, expected: ""},
 		{name: "empty_string", value: "", offset: 0, maxWidth: 10, expected: ""},
 	}
 


### PR DESCRIPTION
## Description

The early return in `ellipsis` has sliced by byte since the registry system went in back in 2024, but `offset` is a rune index everywhere else in the function. You only hit it when the string is short enough that nothing needs truncating, which is why its sat there so long.

Two ways it goes wrong. `ellipsisBoth 2 10` on "héllo" hands back `"\xa9llo"`, because byte 2 lands halfway inside the two-byte é - that isnt valid UTF-8, and it should have been "llo". The other one is worse: `ellipsisBoth 5 10` on "foo" panics with `slice bounds out of range [5:3]`, and through `text/template` that kills the whole render. A value that happens to be shorter than the offset takes the page down with it.

## Changes

Slice by rune on that path. An offset past the end now gives you `""`, which is what `ellipsisBoth 3 10` on "foo" already does. Offset zero still returns `value` untouched, so `ellipsis` doesn't start allocating a rune slice or rewriting invalid bytes to U+FFFD on every call.

I've left `endPos` alone. Its not bounded by the rune count either, so `ellipsisBoth 18 10` on a 20-character string gives you `...st\x00\x00...`, but clamping it and sliding the window left produce different widths, and that looks like your call rather than mine.

## Fixes

Nothing open covering this, and I didn't file one first.

## Checklist
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly. **(nothing to update)**
- [ ] This change requires a change to the documentation on the website. **(no)**

## Additional Information

`task test`, `task lint` and `task test-compatibility` are all green. `task test-doc` as well, which matters here beacuse the `ellipsisBoth 1 10` example in the strings docs goes through the same function, and it still comes out `...ello...`.
